### PR TITLE
added initial upcloud builder, handler and operation

### DIFF
--- a/upcloud/base.go
+++ b/upcloud/base.go
@@ -1,0 +1,40 @@
+package upcloud
+
+// Constructor for BaseUpcloudServiceHandler
+func New_BaseUpcloudServiceHandler(service *UpcloudServiceWrapper) *BaseUpcloudServiceHandler {
+	return &BaseUpcloudServiceHandler{
+		service: service,
+	}
+}
+
+// Base handler with an upcloud service
+type BaseUpcloudServiceHandler struct {
+	service *UpcloudServiceWrapper
+}
+
+// Set the service
+func (base *BaseUpcloudServiceHandler) ServiceWrapper() *UpcloudServiceWrapper {
+	return base.service
+}
+
+/**
+ * Base operations for Upcloud operations, which
+ * allow sharing of Upcloud service across instances
+ */
+
+// Constructor for BaseUpcloudServiceOperation
+func New_BaseUpcloudServiceOperation(service *UpcloudServiceWrapper) *BaseUpcloudServiceOperation {
+	return &BaseUpcloudServiceOperation{
+		service: service,
+	}
+}
+
+// Base operation with an upcloud service
+type BaseUpcloudServiceOperation struct {
+	service *UpcloudServiceWrapper
+}
+
+// Set the service
+func (base *BaseUpcloudServiceOperation) ServiceWrapper() *UpcloudServiceWrapper {
+	return base.service
+}

--- a/upcloud/builder.go
+++ b/upcloud/builder.go
@@ -1,0 +1,76 @@
+package upcloud
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	api_api "github.com/james-nesbitt/kraut-api/api"
+	api_builder "github.com/james-nesbitt/kraut-api/builder"
+	api_handler "github.com/james-nesbitt/kraut-api/handler"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+)
+
+/**
+ * A kraut builder for upcloud handlers
+ */
+
+
+// Upcloud Builder
+type UpcloudBuilder struct {
+	parent api_api.API
+
+	handlers *api_handler.Handlers
+	base_UpcloudServiceHandler *BaseUpcloudServiceHandler
+}
+
+// Set a API for this Handler
+func (builder *UpcloudBuilder) SetAPI(parent api_api.API) {
+	// Keep that api, so that we can use it to make a ConfigWrapper later on
+	builder.parent = parent
+}
+// Initialize and activate the Handler
+func (builder *UpcloudBuilder) Activate(implementations api_builder.Implementations, settings interface{}) error {
+	if builder.handlers == nil {
+		builder.handlers = &api_handler.Handlers{}
+	}
+
+	// This base handler is commonly used in the implementation handlers, so get it once here.
+	baseHandler := builder.base_BaseUpcloudServiceOperation()
+
+	for _, implementation := range implementations.Order() {
+		switch implementation {
+		case "monitor":
+			monitorHandler := UpcloudMonitorHandler{BaseUpcloudServiceHandler: *baseHandler}
+			builder.handlers.Add(api_handler.Handler(&monitorHandler))
+		default:
+			log.WithFields(log.Fields{"implementation": implementation}).Error("Unknown implementation in UpCloud builder")
+		}
+	}
+
+	return nil
+}
+// Rturn a string identifier for the Handler (not functionally needed yet)
+func (builder *UpcloudBuilder) Id() string {
+	return "upcloud"
+}
+// Return a list of Operations from the Handler
+func (builder *UpcloudBuilder) Operations() *api_operation.Operations {
+	ops := builder.handlers.Operations()
+	return &ops
+}
+
+// Return a shared BaseUpcloudServiceOperation for any operation that needs it
+func (builder *UpcloudBuilder) base_BaseUpcloudServiceOperation() *BaseUpcloudServiceHandler {
+	if builder.base_UpcloudServiceHandler == nil {
+		// Builder a configwrapper, which will be used to build upcloud service structs
+		operations := builder.parent.Operations()
+		configWrapper := api_config.New_SimpleConfigWrapper(&operations)
+		// get an upcloud factory, using the config wrapper (probably a file like upcloud.yml)
+		upcloudFactory := New_UpcloudFactoryConfigWrapperYaml(configWrapper)
+
+		// Ask the factory to build the service wrapper, use that to make the base operations
+		serviceWrapper := upcloudFactory.ServiceWrapper()
+		builder.base_UpcloudServiceHandler = New_BaseUpcloudServiceHandler(serviceWrapper)
+	}
+	return builder.base_UpcloudServiceHandler
+}

--- a/upcloud/client.go
+++ b/upcloud/client.go
@@ -1,0 +1,25 @@
+package upcloud
+
+import (
+	upcloud_client "github.com/Jalle19/upcloud-go-sdk/upcloud/client"
+)
+
+
+// Constructor for UpcloudClientSettings
+func New_UpcloudClientSettings(user string, password string) *UpcloudClientSettings {
+	return &UpcloudClientSettings{
+		user: user,
+		password: password,
+	}
+}
+
+// Client Settings property
+type UpcloudClientSettings struct {
+	user string
+	password string  // don't make this public
+}
+
+// Builder an UpCloud client from the settings
+func (settings *UpcloudClientSettings) Client() *upcloud_client.Client {
+	return upcloud_client.New(settings.user, settings.password)
+}

--- a/upcloud/factory.go
+++ b/upcloud/factory.go
@@ -1,0 +1,11 @@
+package upcloud
+
+const (
+	CONFIG_KEY_UPCLOUD = "upcloud"
+)
+
+// A backend for pulling Config for UpCloud configuration
+type UpcloudFactory interface {
+	ServiceWrapper() *UpcloudServiceWrapper
+}
+

--- a/upcloud/factory_configyml.go
+++ b/upcloud/factory_configyml.go
@@ -1,0 +1,129 @@
+package upcloud
+
+import (
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	upcloud_client "github.com/Jalle19/upcloud-go-sdk/upcloud/client"
+	upcloud_service "github.com/Jalle19/upcloud-go-sdk/upcloud/service"
+
+	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+)
+
+/**
+ * This file provides a ConfigWrapper based tool for reading
+ * and creating an UpCloud client/service pair for a project
+ */
+
+/**
+ * Interpreting build config as yml
+ */
+
+// Constructor for UpcloudFactoryConfigWrapperYaml
+func New_UpcloudFactoryConfigWrapperYaml(configWrapper api_config.ConfigWrapper) UpcloudFactory {
+	return UpcloudFactory(&UpcloudFactoryConfigWrapperYaml{
+		configWrapper: configWrapper,
+		ymlFactory: Yml_UpcloudFactory{},
+	})
+}
+
+
+// A BuilderSettingsConfigWrapper, that interprets build config as yml
+type UpcloudFactoryConfigWrapperYaml struct {
+	configWrapper api_config.ConfigWrapper
+	ymlFactory Yml_UpcloudFactory
+}
+
+func (configFactory *UpcloudFactoryConfigWrapperYaml) DefaultScope() string {
+	/**
+	 * @TODO come up with better scopes, but it has to match local conf path keys
+	 * @SEE configconnect/settings_yml.go which has the same issue
+	 */
+	return "project"
+}
+
+func (configFactory *UpcloudFactoryConfigWrapperYaml) safe() {
+	if configFactory.ymlFactory.Empty() {
+		if err := configFactory.Load(); err != nil {
+			log.WithError(err).Error("Could not load build configuration")			
+		}
+	}
+}
+
+// Convert this YML struct into a Client
+func (configFactory *UpcloudFactoryConfigWrapperYaml) Client() *upcloud_client.Client {
+	configFactory.safe()
+	return configFactory.ymlFactory.MakeClient()
+}
+// Convert this YML struct into a Service
+func (configFactory *UpcloudFactoryConfigWrapperYaml) Service() *upcloud_service.Service {
+	configFactory.safe()
+	return configFactory.ymlFactory.MakeService()
+}
+// Convert this YML struct into a ServiceWrapper
+func (configFactory *UpcloudFactoryConfigWrapperYaml) ServiceWrapper() *UpcloudServiceWrapper {
+	configFactory.safe()
+	return configFactory.ymlFactory.MakeServiceWrapper()
+}
+
+// Retrieve values by parsing bytes from the wrapper
+func (configFactory *UpcloudFactoryConfigWrapperYaml) Load() error {
+	configFactory.ymlFactory = Yml_UpcloudFactory{} // reset stored settings so that we can repopulate it.
+
+	log.Debug("Loading UpCloud config")
+
+	if sources, err := configFactory.configWrapper.Get(CONFIG_KEY_UPCLOUD); err == nil {
+		for _, scope := range sources.Order() {
+			scopedSource, _ := sources.Get(scope)
+
+			scopedValues := Yml_UpcloudFactory{} // temporarily hold all settings for a specific scope in this
+			if err := yaml.Unmarshal(scopedSource, &scopedValues); err == nil {
+				log.WithFields(log.Fields{"YmlUser": scopedValues.User, "scope": scope}).Debug("First UpCloud settings yml")
+				configFactory.ymlFactory = scopedValues
+			} else {
+				log.WithError(err).WithFields(log.Fields{"scope": scope}).Error("Couldn't marshall yml scope for upcloud settings")
+			}
+		}
+		return nil
+	} else {
+		log.WithError(err).Error("Error loading Upcloud config")
+		return err
+	}
+}
+
+// Save the current values to the wrapper
+func (configFactory *UpcloudFactoryConfigWrapperYaml) Save() error {
+	/**
+	 * @TODO THIS
+     */
+	return errors.New("UpcloudFactoryConfigWrapperYaml Set operation not yet written.")
+}
+
+// A temporary holder of BuildSettings, just for yml parsing (probably not needed even)
+type Yml_UpcloudFactory struct {
+	scope string
+
+	User string 				`yaml:"User"`
+	Password string 	        `yaml:"Password"`
+	Hosts []string				`yaml:"Hosts"`
+}
+// Is this struct populated?
+func (ymlFactory *Yml_UpcloudFactory) Empty() bool {
+	return ymlFactory.User == ""
+}
+// Convert this YML struct into a Client
+func (ymlFactory *Yml_UpcloudFactory) MakeClient() *upcloud_client.Client {
+	return New_UpcloudClientSettings(ymlFactory.User, ymlFactory.Password).Client()
+}
+// Convert this YML struct into a Service
+func (ymlFactory *Yml_UpcloudFactory) MakeService() *upcloud_service.Service {
+	client := ymlFactory.MakeClient()
+	return New_UpcloudServiceSettings(*client, ymlFactory.Hosts).Service()
+}
+// Convert this YML struct into a Service
+func (ymlFactory *Yml_UpcloudFactory) MakeServiceWrapper() *UpcloudServiceWrapper {
+	client := ymlFactory.MakeClient()
+	return New_UpcloudServiceSettings(*client, ymlFactory.Hosts).ServiceWrapper()
+}

--- a/upcloud/monitor.go
+++ b/upcloud/monitor.go
@@ -1,0 +1,136 @@
+package upcloud
+
+import (
+	log "github.com/Sirupsen/logrus"
+	
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+)
+/**
+ * Monitor handler for Upcloud operations
+ */ 
+type UpcloudMonitorHandler struct {
+	BaseUpcloudServiceHandler
+}
+
+// Initialize and activate the Handler
+func (monitor *UpcloudMonitorHandler) Init() api_operation.Result {
+	result := api_operation.BaseResult{}
+	result.Set(true, []error{})
+	return api_operation.Result(&result)
+}
+// Rturn a string identifier for the Handler (not functionally needed yet)
+func (monitor *UpcloudMonitorHandler) Id() string {
+	return "upcloud.monitor"
+}
+// Return a list of Operations from the Handler
+func (monitor *UpcloudMonitorHandler) Operations() *api_operation.Operations {
+	ops := api_operation.Operations{}
+
+	baseOperation := New_BaseUpcloudServiceOperation(monitor.ServiceWrapper())
+
+	ops.Add(api_operation.Operation(UpcloudMonitorListServersOperation{BaseUpcloudServiceOperation: *baseOperation}))
+
+	return &ops
+}
+
+/**
+ * Monitor operations for UpCloud
+ */
+type UpcloudMonitorTestOperation struct {
+	BaseUpcloudServiceOperation
+}
+// Return the string machinename/id of the Operation
+func (monTest UpcloudMonitorTestOperation) Id() string {
+	return "upcloud.monitor.test"
+}
+// Return a user readable string label for the Operation
+func (monTest UpcloudMonitorTestOperation) Label() string {
+	return "Test upcloud monitor operation"
+}
+// return a multiline string description for the Operation
+func (monTest UpcloudMonitorTestOperation) Description() string {
+	return "Test upcloud monitor operation"
+}
+
+// Is this operation meant to be used only inside the API
+func (monTest UpcloudMonitorTestOperation) Internal() bool {
+	return false
+}
+
+// FUNCTIONAL
+
+// Run a validation check on the Operation
+func (monTest UpcloudMonitorTestOperation) Validate() bool {
+	return true
+}
+
+// What settings/values does the Operation provide to an implemenentor
+func (monTest UpcloudMonitorTestOperation) Properties() *api_operation.Properties {
+	props := api_operation.Properties{}
+
+	return &props
+}
+
+// Execute the Operation
+func (monTest UpcloudMonitorTestOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
+	result.Set(true, []error{})
+	return api_operation.Result(&result)
+}
+
+/**
+ * Monitor operations for UpCloud
+ */
+type UpcloudMonitorListServersOperation struct {
+	BaseUpcloudServiceOperation
+}
+// Return the string machinename/id of the Operation
+func (list UpcloudMonitorListServersOperation) Id() string {
+	return "upcloud.monitor.list.servers"
+}
+// Return a user readable string label for the Operation
+func (list UpcloudMonitorListServersOperation) Label() string {
+	return "UpCloud server list"
+}
+// return a multiline string description for the Operation
+func (list UpcloudMonitorListServersOperation) Description() string {
+	return "List UpCloud servers used in the project"
+}
+
+// Is this operation meant to be used only inside the API
+func (list UpcloudMonitorListServersOperation) Internal() bool {
+	return false
+}
+
+// FUNCTIONAL
+
+// Run a validation check on the Operation
+func (list UpcloudMonitorListServersOperation) Validate() bool {
+	return true
+}
+
+// What settings/values does the Operation provide to an implemenentor
+func (list UpcloudMonitorListServersOperation) Properties() *api_operation.Properties {
+	props := api_operation.Properties{}
+
+	return &props
+}
+
+// Execute the Operation
+func (list UpcloudMonitorListServersOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
+	result.Set(true, []error{})
+
+	service := list.ServiceWrapper()
+
+	servers, err := service.GetServers()
+	if err == nil {
+		for index, server := range servers.Servers {
+			log.WithFields(log.Fields{"index": index, "server": server}).Info("Server")
+		}
+	} else {
+		log.WithError(err).Error("Could not list UpCloud servers")		
+	}
+
+	return api_operation.Result(&result)
+}

--- a/upcloud/property.go
+++ b/upcloud/property.go
@@ -1,0 +1,5 @@
+package upcloud
+
+/**
+ * Custom properties for the upcloud operations
+ */

--- a/upcloud/service.go
+++ b/upcloud/service.go
@@ -1,0 +1,55 @@
+package upcloud
+
+import (
+	upcloud_client "github.com/Jalle19/upcloud-go-sdk/upcloud/client"
+	upcloud_service "github.com/Jalle19/upcloud-go-sdk/upcloud/service"
+)
+
+/**
+ * UpCloud SDK service wrapper
+ */
+
+// Constructor for UpcloudServiceSettings
+func New_UpcloudServiceSettings(client upcloud_client.Client, hosts []string) *UpcloudServiceSettings {
+	return &UpcloudServiceSettings{
+		client: client,
+		hosts: hosts,
+	}
+}
+
+// Settings for the 
+type UpcloudServiceSettings struct {
+	client upcloud_client.Client
+
+	hosts []string
+}
+// Get an Upcloud service from these settings
+func (serviceSettings UpcloudServiceSettings) Service() *upcloud_service.Service {
+	return New_UpcloudServiceFromClient(serviceSettings.client)
+}
+
+// Get an Upcloud service from these settings
+func (serviceSettings UpcloudServiceSettings) ServiceWrapper() *UpcloudServiceWrapper {
+	service := serviceSettings.Service()
+	return New_UpcloudServiceWrapper(*service)
+}
+
+
+// Constructor for upcloud Service from a client
+func New_UpcloudServiceFromClient(client upcloud_client.Client) *upcloud_service.Service {
+	service := upcloud_service.New(&client)
+	return service
+}
+
+
+// Constructor for UpcloudServiceWrapper
+func New_UpcloudServiceWrapper(service upcloud_service.Service) *UpcloudServiceWrapper {
+	return &UpcloudServiceWrapper{
+		Service: service,
+	}
+}
+
+// Wrapper for the upcloud service, so that we can limit operations
+type UpcloudServiceWrapper struct {
+	upcloud_service.Service
+}


### PR DESCRIPTION
This patch includes all of the builder and handler functionality for UpCloud.  Initially just a server-list monitor operation is exposed.

This typically requires that you have an "upcloud" config (./kraut/upcloud.yml) with some client credentials.
The builder is expected to receive settings that limit the UpCloud api to architecture in scope for the project - typicall a host list.  This part is not truly impemented yet.