### PR TITLE
update handler builders to use builder settings provider

### DIFF
--- a/configconnect/builder_yaml.go
+++ b/configconnect/builder_yaml.go
@@ -104,11 +104,26 @@ func (buildSettings *BuilderSettingsConfigWrapperYaml) Save() error {
 
 // A temporary holder of BuildSettings, just for yml parsing (probably not needed even)
 type Yml_BuildSetting struct {
-	Type string 				`yaml:"Type"`
-	Implementations []string 	`yaml:"Implementations"`
-	Settings interface{} 		`yaml:"Settings"`
+	Type string 				                       `yaml:"Type"`
+	Implementations []string 	                       `yaml:"Implementations"`
+	SettingsProvider Yml_BuildSettingSettingsProvider  `yaml:"Settings"`
 }
 // Convert this YML struct into a proper BuildSetting struct
 func (setting *Yml_BuildSetting) MakeBuildSetting() *api_builder.BuildSetting {
-	return api_builder.New_BuildSetting(setting.Type, *api_builder.New_Implementations(setting.Implementations), setting.Settings)
+	return api_builder.New_BuildSetting(setting.Type, *api_builder.New_Implementations(setting.Implementations), api_builder.SettingsProvider(setting.SettingsProvider))
+}
+
+// Yml builder SettingProvider
+type Yml_BuildSettingSettingsProvider struct {
+	UnMarshaler func(interface{}) error
+}
+// Yaml custom UnMarshall handler
+func (ymlSettingsProvider *Yml_BuildSettingSettingsProvider) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	ymlSettingsProvider.UnMarshaler = unmarshal
+	return nil
+}
+
+// UnMarshaller function
+func (ymlSettingsProvider Yml_BuildSettingSettingsProvider) AssignSettings(target interface{}) error {
+	return ymlSettingsProvider.UnMarshaler(target)
 }

--- a/local/builder.go
+++ b/local/builder.go
@@ -58,7 +58,7 @@ func (builder *LocalBuilder) SetAPI(parent api_api.API) {
 }
 
 // Initialize the handler for certain implementations
-func (builder *LocalBuilder) Activate(implementations api_builder.Implementations, settings interface{}) error {
+func (builder *LocalBuilder) Activate(implementations api_builder.Implementations, settingsProvider api_builder.SettingsProvider) error {
 	for _, implementation := range implementations.Order() {
 		switch(implementation) {
 		case "config":

--- a/null/builder.go
+++ b/null/builder.go
@@ -28,7 +28,7 @@ func (builder *NullBuilder) SetAPI(parent api_api.API) {
 }
 
 // Initialize and activate the Handler
-func (builder *NullBuilder) Activate(implementations api_builder.Implementations, settings interface{}) error {
+func (builder *NullBuilder) Activate(implementations api_builder.Implementations, settingsProvider api_builder.SettingsProvider) error {
 	for _, implementation := range implementations.Order() {
 		found := false
 		for _, existing := range builder.activated {


### PR DESCRIPTION
This patch updates all of the existing handler builders, to use the new settingsprovider builder settings approach from the api