### PR TITLE
cleaned up handler imports, remapped configconnect to configwrapper

### DIFF
--- a/bytesource/base.go
+++ b/bytesource/base.go
@@ -1,7 +1,7 @@
 package bytesource
 
 import (
-	"github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
 )
 
 /**
@@ -17,16 +17,16 @@ func New_BaseBytesourceFilesettingsOperation(settings BytesourceFileSettings) *B
 
 type BaseBytesourceFilesettingsOperation struct {
 	settings   BytesourceFileSettings
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
-func (base *BaseBytesourceFilesettingsOperation) Properties() *operation.Properties {
+func (base *BaseBytesourceFilesettingsOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
 		settingsProp := BytesourceFilesettingsProperty{}
 		settingsProp.Set(base.settings)
 
-		base.properties = &operation.Properties{}
-		base.properties.Add(operation.Property(&settingsProp))
+		base.properties = &api_operation.Properties{}
+		base.properties.Add(api_operation.Property(&settingsProp))
 	}
 	return base.properties
 }

--- a/bytesource/file_configconnect_yml.go
+++ b/bytesource/file_configconnect_yml.go
@@ -1,12 +1,16 @@
-package configconnect
+package bytesource
+
+/**
+ * Build a ConfigConnector based on file contents
+ */
+
 
 import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 
-	"github.com/james-nesbitt/kraut-handlers/bytesource"
-	"github.com/james-nesbitt/kraut-api/operation/config"
+	api_config "github.com/james-nesbitt/kraut-api/operation/config"
 )
 
 const (
@@ -15,7 +19,7 @@ const (
 )
 
 // Constructor for ConfigConnectYmlFiles
-func New_ConfigConnectYmlFiles(paths *bytesource.Paths) *ConfigConnectYmlFiles {
+func New_ConfigConnectYmlFiles(paths *Paths) *ConfigConnectYmlFiles {
 	return &ConfigConnectYmlFiles{
 		paths: paths,
 	}
@@ -23,15 +27,15 @@ func New_ConfigConnectYmlFiles(paths *bytesource.Paths) *ConfigConnectYmlFiles {
 
 // A ConfigConnector that looks for files
 type ConfigConnectYmlFiles struct {
-	paths *bytesource.Paths
+	paths *Paths
 }
 
 func (connect *ConfigConnectYmlFiles) convertKeyToFileName(key string) string {
 	return strings.ToLower(key) + ".yml"
 }
 
-func (connect *ConfigConnectYmlFiles) findKey(key string) *bytesource.Files {
-	files := bytesource.Files{}
+func (connect *ConfigConnectYmlFiles) findKey(key string) *Files {
+	files := Files{}
 	filename := connect.convertKeyToFileName(key)
 
 	for _, pathKey := range connect.paths.Order() {
@@ -43,8 +47,8 @@ func (connect *ConfigConnectYmlFiles) findKey(key string) *bytesource.Files {
 	return &files
 }
 
-func (connect *ConfigConnectYmlFiles) Readers(key string) config.ScopedReaders {
-	readers := config.ScopedReaders{}
+func (connect *ConfigConnectYmlFiles) Readers(key string) api_config.ScopedReaders {
+	readers := api_config.ScopedReaders{}
 
 	files := connect.findKey(key)
 	for _, fileKey := range files.Order() {
@@ -56,8 +60,8 @@ func (connect *ConfigConnectYmlFiles) Readers(key string) config.ScopedReaders {
 
 	return readers
 }
-func (connect *ConfigConnectYmlFiles) Writers(key string) config.ScopedWriters {
-	writers := config.ScopedWriters{}
+func (connect *ConfigConnectYmlFiles) Writers(key string) api_config.ScopedWriters {
+	writers := api_config.ScopedWriters{}
 
 	files := connect.findKey(key)
 	for _, fileKey := range files.Order() {

--- a/configconnect/document_yaml.go
+++ b/configconnect/document_yaml.go
@@ -1,1 +1,0 @@
-package configconnect

--- a/configwrapper/builder.go
+++ b/configwrapper/builder.go
@@ -1,4 +1,4 @@
-package configconnect
+package configwrapper
 
 /**
  * Builder building by reading config bytes

--- a/configwrapper/builder_yaml.go
+++ b/configwrapper/builder_yaml.go
@@ -1,4 +1,4 @@
-package configconnect
+package configwrapper
 
 import (
 	"errors"

--- a/configwrapper/document.go
+++ b/configwrapper/document.go
@@ -1,4 +1,4 @@
-package configconnect
+package configwrapper
 
 const (
 	// The Config key for documentation

--- a/configwrapper/document_yaml.go
+++ b/configwrapper/document_yaml.go
@@ -1,0 +1,1 @@
+package configwrapper

--- a/configwrapper/setting.go
+++ b/configwrapper/setting.go
@@ -1,12 +1,12 @@
-package configconnect
+package configwrapper
 
 import (
 	"errors"
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/setting"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
 )
 
 const (
@@ -173,8 +173,8 @@ func (values *SettingValues) Get(scope string) ([]byte, bool) {
 
 // A Setting Get operation that uses a ConfigWrapper to retrieve values
 type SettingConfigWrapperGetOperation struct {
-	setting.BaseSettingGetOperation
-	setting.BaseSettingKeyScopeValueOperation
+	api_setting.BaseSettingGetOperation
+	api_setting.BaseSettingKeyScopeValueOperation
 	Wrapper SettingsConfigWrapper
 }
 
@@ -182,16 +182,19 @@ type SettingConfigWrapperGetOperation struct {
 func (get SettingConfigWrapperGetOperation) Validate() bool {
 	return true
 }
+func (get SettingConfigWrapperGetOperation) Internal() bool {
+	return false
+}
 
 // Execute the operation
-func (get SettingConfigWrapperGetOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (get SettingConfigWrapperGetOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := get.Properties()
-	keyProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_KEY)
-	scopeProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_SCOPE)
-	valueProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_VALUE)
+	keyProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_KEY)
+	scopeProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_SCOPE)
+	valueProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_VALUE)
 
 	if key, ok := keyProp.Get().(string); ok {
 		if value, ok := get.Wrapper.Get(key); ok {
@@ -240,12 +243,12 @@ func (get SettingConfigWrapperGetOperation) Exec() operation.Result {
 		result.Set(false, []error{errors.New("Could not get a string value for Key from the config connector")})
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 // A Setting Set operation that uses a ConfigWrapper to assign values
 type SettingConfigWrapperSetOperation struct {
-	setting.BaseSettingSetOperation
+	api_setting.BaseSettingSetOperation
 	Wrapper SettingsConfigWrapper
 }
 
@@ -255,14 +258,14 @@ func (set SettingConfigWrapperSetOperation) Validate() bool {
 }
 
 // Execute the operation
-func (set SettingConfigWrapperSetOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (set SettingConfigWrapperSetOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := set.Properties()
-	keyProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_KEY)
-	scopeProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_SCOPE)
-	valueProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_VALUE)
+	keyProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_KEY)
+	scopeProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_SCOPE)
+	valueProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_VALUE)
 
 	if key, okKey := keyProp.Get().(string); okKey {
 		if value, okValue := valueProp.Get().([]byte); okValue {
@@ -280,19 +283,19 @@ func (set SettingConfigWrapperSetOperation) Exec() operation.Result {
 				log.WithFields(log.Fields{"key": okKey, "scope": scope, "values": values}).Debug("Set config value")
 			}
 		} else {
-			result.Set(false, []error{errors.New("Could not retrieve Value property for setting Set operation. No value to set.")})
+			result.Set(false, []error{errors.New("Could not retrieve Value property for setting Set api_operation. No value to set.")})
 		}
 	} else {
 		result.Set(false, []error{errors.New("Could not assign value to key property for setting Set operation")})
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 //A setting List operation that uses a ConfigWrapper to list keys
 type SettingConfigWrapperListOperation struct {
-	setting.BaseSettingListOperation
-	setting.BaseSettingKeyScopeKeysOperation
+	api_setting.BaseSettingListOperation
+	api_setting.BaseSettingKeyScopeKeysOperation
 	Wrapper SettingsConfigWrapper
 }
 
@@ -302,13 +305,13 @@ func (list SettingConfigWrapperListOperation) Validate() bool {
 }
 
 // Execute the operation
-func (list SettingConfigWrapperListOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (list SettingConfigWrapperListOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := list.BaseSettingKeyScopeKeysOperation.Properties()
-	keyProp, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_KEY)
-	keysConf, _ := props.Get(setting.OPERATION_PROPERTY_SETTING_KEYS)
+	keyProp, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_KEY)
+	keysConf, _ := props.Get(api_setting.OPERATION_PROPERTY_SETTING_KEYS)
 
 	if key, ok := keyProp.Get().(string); ok && key != "" {
 		keysConf.Set(list.Wrapper.List(key))
@@ -316,5 +319,5 @@ func (list SettingConfigWrapperListOperation) Exec() operation.Result {
 		keysConf.Set(list.Wrapper.List(""))
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/configwrapper/setting_yaml.go
+++ b/configwrapper/setting_yaml.go
@@ -1,4 +1,4 @@
-package configconnect
+package configwrapper
 
 import (
 	// "errors"
@@ -7,16 +7,16 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"github.com/james-nesbitt/kraut-api/operation/config"
+	api_config "github.com/james-nesbitt/kraut-api/operation/config"
 )
 
 /**
- * A single base struct which handles settings by intepreting a config.ConfigWrapper
+ * A single base struct which handles settings by intepreting an api_config.ConfigWrapper
  * as a stream of YML bytes,
  */
 
 // Constructor for {} BaseSettingConfigWrapperYmlOperation
-func New_BaseSettingConfigWrapperYmlOperation(wrapper config.ConfigWrapper) *BaseSettingConfigWrapperYmlOperation {
+func New_BaseSettingConfigWrapperYmlOperation(wrapper api_config.ConfigWrapper) *BaseSettingConfigWrapperYmlOperation {
 	return &BaseSettingConfigWrapperYmlOperation{
 		wrapper:  wrapper,
 		settings: Settings{},
@@ -25,7 +25,7 @@ func New_BaseSettingConfigWrapperYmlOperation(wrapper config.ConfigWrapper) *Bas
 
 // A SettingsSource implementation for yml settings
 type BaseSettingConfigWrapperYmlOperation struct {
-	wrapper  config.ConfigWrapper // The config wrapper will be used to retrieve and save full config
+	wrapper  api_config.ConfigWrapper // The config wrapper will be used to retrieve and save full config
 	settings Settings             // the values map stores parsed values from config
 }
 
@@ -70,10 +70,10 @@ func (setting *BaseSettingConfigWrapperYmlOperation) Save() error {
 	}
 
 	// convert the map to a ConfigScopedValues{} by marshalling the settings maps
-	scopedValues := config.ConfigScopedValues{}
+	scopedValues := api_config.ConfigScopedValues{}
 	for scope, values := range configMap {
 		if valuesYml, err := yaml.Marshal(values); err == nil {
-			scopedValues.Add(scope, config.ConfigScopedValue(valuesYml))
+			scopedValues.Add(scope, api_config.ConfigScopedValue(valuesYml))
 		} else {
 			return err
 		}

--- a/libcompose/base.go
+++ b/libcompose/base.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/james-nesbitt/kraut-handlers/bytesource"
-	"github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
 )
 
 /**
@@ -19,7 +19,7 @@ import (
  * Handlers
  */
 
-func New_BaseLibcomposeHandler(projectName string, dockerComposeFiles []string, runContext context.Context, outputWriter io.Writer, errorWriter io.Writer, filesettings bytesource.BytesourceFileSettings) *BaseLibcomposeHandler {
+func New_BaseLibcomposeHandler(projectName string, dockerComposeFiles []string, runContext context.Context, outputWriter io.Writer, errorWriter io.Writer, filesettings handlers_bytesource.BytesourceFileSettings) *BaseLibcomposeHandler {
 	baseLibcomposeOp, _ := New_BaseLibcomposeNameFilesOperation(projectName, dockerComposeFiles, runContext, outputWriter, errorWriter, filesettings)
 	base := &BaseLibcomposeHandler{LibComposeBaseOp: &baseLibcomposeOp}
 	return base
@@ -35,8 +35,8 @@ type BaseLibcomposeHandler struct {
  */
 
 // A handoff function to make a base orchestration operation, which is really just a lot of linear code.
-func New_BaseLibcomposeNameFilesOperation(projectName string, dockerComposeFiles []string, runContext context.Context, outputWriter io.Writer, errorWriter io.Writer, filesettings bytesource.BytesourceFileSettings) (BaseLibcomposeNameFilesOperation, operation.Result) {
-	result := operation.BaseResult{}
+func New_BaseLibcomposeNameFilesOperation(projectName string, dockerComposeFiles []string, runContext context.Context, outputWriter io.Writer, errorWriter io.Writer, filesettings handlers_bytesource.BytesourceFileSettings) (BaseLibcomposeNameFilesOperation, api_operation.Result) {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	// This Base operations will be at the root of all of the libCompose operations
@@ -53,7 +53,7 @@ func New_BaseLibcomposeNameFilesOperation(projectName string, dockerComposeFiles
 	}
 
 	// Add project context
-	if projectFilesettingsConf, found := orchestrateProperties.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); found {
+	if projectFilesettingsConf, found := orchestrateProperties.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); found {
 		if !projectFilesettingsConf.Set(filesettings) {
 			result.Set(false, []error{errors.New("Could not set base libcompose file settings.  Config set error on base Orchestration operation")})
 		}
@@ -93,28 +93,28 @@ func New_BaseLibcomposeNameFilesOperation(projectName string, dockerComposeFiles
 		result.Set(false, []error{errors.New("Could not set base libcompose error handler.  Config not found on base Orchestration operation")})
 	}
 
-	return baseLibcomposeOrchestrate, operation.Result(&result)
+	return baseLibcomposeOrchestrate, api_operation.Result(&result)
 }
 
 // A base libcompose operation with Properties for project-name, and yml files
 type BaseLibcomposeNameFilesOperation struct {
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Provide static Properties for the operation
-func (base *BaseLibcomposeNameFilesOperation) Properties() *operation.Properties {
+func (base *BaseLibcomposeNameFilesOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 
-		newProperties.Add(operation.Property(&LibcomposeProjectnameProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeProjectnameProperty{}))
 
-		newProperties.Add(operation.Property(&bytesource.BytesourceFilesettingsProperty{}))
+		newProperties.Add(api_operation.Property(&handlers_bytesource.BytesourceFilesettingsProperty{}))
 
-		newProperties.Add(operation.Property(&LibcomposeComposefilesProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeContextProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeComposefilesProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeContextProperty{}))
 
-		newProperties.Add(operation.Property(&LibcomposeOutputProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeErrorProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeOutputProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeErrorProperty{}))
 
 		base.properties = newProperties
 	}

--- a/libcompose/command.go
+++ b/libcompose/command.go
@@ -3,8 +3,8 @@ package libcompose
 import (
 	"errors"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/command"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_command "github.com/james-nesbitt/kraut-api/operation/command"
 )
 
 /**
@@ -28,12 +28,12 @@ type CommandConfigWrapper interface {
 
 // LibCompose Command List operation
 type LibcomposeCommandListOperation struct {
-	command.BaseCommandListOperation
-	command.BaseCommandKeyKeysOperation
+	api_command.BaseCommandListOperation
+	api_command.BaseCommandKeyKeysOperation
 	BaseLibcomposeNameFilesOperation
 
 	Wrapper    CommandConfigWrapper
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Validate the operation
@@ -42,7 +42,7 @@ func (list *LibcomposeCommandListOperation) Validate() bool {
 }
 
 // Get properties
-func (list *LibcomposeCommandListOperation) Properties() *operation.Properties {
+func (list *LibcomposeCommandListOperation) Properties() *api_operation.Properties {
 	baseProps := list.BaseCommandListOperation.Properties()
 
 	keyKeysProps := list.BaseCommandKeyKeysOperation.Properties()
@@ -52,13 +52,13 @@ func (list *LibcomposeCommandListOperation) Properties() *operation.Properties {
 }
 
 // Execute the libCompose Command List operation
-func (list *LibcomposeCommandListOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (list *LibcomposeCommandListOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := list.BaseCommandKeyKeysOperation.Properties()
-	keyProp, _ := props.Get(command.OPERATION_PROPERTY_COMMAND_KEY)
-	keysProp, _ := props.Get(command.OPERATION_PROPERTY_COMMAND_KEYS)
+	keyProp, _ := props.Get(api_command.OPERATION_PROPERTY_COMMAND_KEY)
+	keysProp, _ := props.Get(api_command.OPERATION_PROPERTY_COMMAND_KEYS)
 
 	parent := ""
 	if key, ok := keyProp.Get().(string); ok && key != "" {
@@ -71,17 +71,17 @@ func (list *LibcomposeCommandListOperation) Exec() operation.Result {
 		result.Set(false, []error{err})
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 // LibCompose Command Get operation
 type LibcomposeCommandGetOperation struct {
-	command.BaseCommandGetOperation
-	command.BaseCommandKeyCommandOperation
+	api_command.BaseCommandGetOperation
+	api_command.BaseCommandKeyCommandOperation
 	BaseLibcomposeNameFilesOperation
 
 	Wrapper    CommandConfigWrapper
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Validate the operation
@@ -90,7 +90,7 @@ func (get *LibcomposeCommandGetOperation) Validate() bool {
 }
 
 // Get properties
-func (get *LibcomposeCommandGetOperation) Properties() *operation.Properties {
+func (get *LibcomposeCommandGetOperation) Properties() *api_operation.Properties {
 	baseProps := get.BaseCommandGetOperation.Properties()
 
 	keyCommandProps := get.BaseCommandKeyCommandOperation.Properties()
@@ -100,13 +100,13 @@ func (get *LibcomposeCommandGetOperation) Properties() *operation.Properties {
 }
 
 // Execute the libCompose Command Get operation
-func (get *LibcomposeCommandGetOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (get *LibcomposeCommandGetOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := get.BaseCommandKeyCommandOperation.Properties()
-	keyProp, _ := props.Get(command.OPERATION_PROPERTY_COMMAND_KEY)
-	commandProp, _ := props.Get(command.OPERATION_PROPERTY_COMMAND_COMMAND)
+	keyProp, _ := props.Get(api_command.OPERATION_PROPERTY_COMMAND_KEY)
+	commandProp, _ := props.Get(api_command.OPERATION_PROPERTY_COMMAND_COMMAND)
 
 	if key, ok := keyProp.Get().(string); ok && key != "" {
 
@@ -122,5 +122,5 @@ func (get *LibcomposeCommandGetOperation) Exec() operation.Result {
 		result.Set(false, []error{errors.New("No command name provided.")})
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/libcompose/command_yaml.go
+++ b/libcompose/command_yaml.go
@@ -11,13 +11,13 @@ import (
 	libCompose_config "github.com/docker/libcompose/config"
 	libCompose_project_options "github.com/docker/libcompose/project/options"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/command"
-	"github.com/james-nesbitt/kraut-api/operation/config"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_command "github.com/james-nesbitt/kraut-api/operation/command"
+	api_config "github.com/james-nesbitt/kraut-api/operation/config"
 )
 
 // Constructor for BaseCommandConfigWrapperYmlOperation
-func New_BaseCommandConfigWrapperYmlOperation(configWrapper config.ConfigWrapper) *BaseCommandConfigWrapperYmlOperation {
+func New_BaseCommandConfigWrapperYmlOperation(configWrapper api_config.ConfigWrapper) *BaseCommandConfigWrapperYmlOperation {
 	return &BaseCommandConfigWrapperYmlOperation{
 		wrapper:  configWrapper,
 		commands: &CommandYmlCommands{},
@@ -26,7 +26,7 @@ func New_BaseCommandConfigWrapperYmlOperation(configWrapper config.ConfigWrapper
 
 // Command config wrapper that reads YML commands
 type BaseCommandConfigWrapperYmlOperation struct {
-	wrapper  config.ConfigWrapper
+	wrapper  api_config.ConfigWrapper
 	commands *CommandYmlCommands
 }
 
@@ -169,7 +169,7 @@ type CommandYmlCommand struct {
 	internal   bool
 
 	project       *ComposeProject
-	properties    *operation.Properties
+	properties    *api_operation.Properties
 	serviceConfig libCompose_config.ServiceConfig
 }
 
@@ -199,9 +199,9 @@ func (comm *CommandYmlCommand) UnmarshalYAML(unmarshal func(interface{}) error) 
 	}
 
 	if comm.properties == nil {
-		properties := operation.Properties{}
+		properties := api_operation.Properties{}
 
-		properties.Add(operation.Property(&command.CommandFlagsProperty{}))
+		properties.Add(api_operation.Property(&api_command.CommandFlagsProperty{}))
 
 		comm.properties = &properties
 	}
@@ -210,11 +210,11 @@ func (comm *CommandYmlCommand) UnmarshalYAML(unmarshal func(interface{}) error) 
 }
 
 // Turn this CommandYmlCommand into a command.Command
-func (ymlCommand *CommandYmlCommand) Command(projectProps *operation.Properties) command.Command {
+func (ymlCommand *CommandYmlCommand) Command(projectProps *api_operation.Properties) api_command.Command {
 	// merge the properties, keeping local over project.
 	projectProps.Merge(*ymlCommand.Properties())
 	ymlCommand.properties = projectProps
-	return command.Command(ymlCommand)
+	return api_command.Command(ymlCommand)
 }
 
 // Return string Id
@@ -255,16 +255,16 @@ func (ymlCommand *CommandYmlCommand) Description() string {
 }
 
 // Return string Description
-func (ymlCommand *CommandYmlCommand) Properties() *operation.Properties {
+func (ymlCommand *CommandYmlCommand) Properties() *api_operation.Properties {
 	return ymlCommand.properties
 }
 
-func (ymlCommand *CommandYmlCommand) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (ymlCommand *CommandYmlCommand) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	flags := []string{}
-	if propFlags, found := ymlCommand.Properties().Get(command.OPERATION_PROPERTY_COMMAND_FLAGS); found {
+	if propFlags, found := ymlCommand.Properties().Get(api_command.OPERATION_PROPERTY_COMMAND_FLAGS); found {
 		flags = propFlags.Get().([]string)
 	}
 
@@ -294,5 +294,5 @@ func (ymlCommand *CommandYmlCommand) Exec() operation.Result {
 		project.Delete(runContext, deleteOptions, ymlCommand.Id())
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/libcompose/libcompose.go
+++ b/libcompose/libcompose.go
@@ -10,8 +10,8 @@ import (
 	libCompose_dockerctx "github.com/docker/libcompose/docker/ctx"
 	libCompose_project "github.com/docker/libcompose/project"
 
-	"github.com/james-nesbitt/kraut-handlers/bytesource"
-	"github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"
 )
 
 /**
@@ -19,13 +19,13 @@ import (
  * are needed to handler orchestration through libcompose
  */
 
-func MakeComposeProject(properties *operation.Properties) (*ComposeProject, bool) {
+func MakeComposeProject(properties *api_operation.Properties) (*ComposeProject, bool) {
 
 	projectNameProp, _ := properties.Get(OPERATION_PROPERTY_LIBCOMPOSE_PROJECTNAME)
 	composeProjectName := projectNameProp.Get().(string)
 
-	bytesourceFilesettingsProp, _ := properties.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
-	pathSettings := bytesourceFilesettingsProp.Get().(bytesource.BytesourceFileSettings)
+	bytesourceFilesettingsProp, _ := properties.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
+	pathSettings := bytesourceFilesettingsProp.Get().(handlers_bytesource.BytesourceFileSettings)
 
 	projectFilesProp, _ := properties.Get(OPERATION_PROPERTY_LIBCOMPOSE_COMPOSEFILES)
 	composeFiles := projectFilesProp.Get().([]string)
@@ -71,7 +71,7 @@ type ComposeProject struct {
 	libCompose_project.APIProject
 	netContext     context.Context
 	composeContext *libCompose_dockerctx.Context
-	pathSettings   bytesource.BytesourceFileSettings
+	pathSettings   handlers_bytesource.BytesourceFileSettings
 }
 
 // get a specific service

--- a/libcompose/monitor.go
+++ b/libcompose/monitor.go
@@ -7,8 +7,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/monitor"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_monitor "github.com/james-nesbitt/kraut-api/operation/monitor"
 )
 
 /**
@@ -17,15 +17,15 @@ import (
  */
 
 const (
-	OPERATION_ID_COMPOSE_MONITOR_LOGS = monitor.OPERATION_ID_MONITOR_LOGS + ".compose"
+	OPERATION_ID_COMPOSE_MONITOR_LOGS = api_monitor.OPERATION_ID_MONITOR_LOGS + ".compose"
 )
 
 // An operations which streams the container logs from libcompose
 type LibcomposeMonitorLogsOperation struct {
-	monitor.BaseMonitorLogsOperation
+	api_monitor.BaseMonitorLogsOperation
 	BaseLibcomposeNameFilesOperation
 
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Use a different Id() than the parent
@@ -39,9 +39,9 @@ func (logs *LibcomposeMonitorLogsOperation) Validate() bool {
 }
 
 // Provide static properties for the operation
-func (logs *LibcomposeMonitorLogsOperation) Properties() *operation.Properties {
+func (logs *LibcomposeMonitorLogsOperation) Properties() *api_operation.Properties {
 	if logs.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 		newProperties.Add(&LibcomposeDetachProperty{})
 		newProperties.Merge(*logs.BaseLibcomposeNameFilesOperation.Properties())
 		logs.properties = newProperties
@@ -50,8 +50,8 @@ func (logs *LibcomposeMonitorLogsOperation) Properties() *operation.Properties {
 }
 
 // Execute the libCompose monitor logs operation
-func (logs *LibcomposeMonitorLogsOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (logs *LibcomposeMonitorLogsOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	properties := logs.Properties()
@@ -87,5 +87,5 @@ func (logs *LibcomposeMonitorLogsOperation) Exec() operation.Result {
 		}
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/libcompose/orchestrate_down.go
+++ b/libcompose/orchestrate_down.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
 )
 
 /**
@@ -65,15 +65,15 @@ func (optionsConf *LibcomposeOptionsDownProperty) Set(value interface{}) bool {
 
 // Base Down operation
 type BaseLibcomposeOrchestrateDownSingleOperation struct {
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Provide static Properties for the operation
-func (base *BaseLibcomposeOrchestrateDownSingleOperation) Properties() *operation.Properties {
+func (base *BaseLibcomposeOrchestrateDownSingleOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 
-		newProperties.Add(operation.Property(&LibcomposeOptionsDownProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeOptionsDownProperty{}))
 
 		base.properties = newProperties
 	}
@@ -82,17 +82,17 @@ func (base *BaseLibcomposeOrchestrateDownSingleOperation) Properties() *operatio
 
 // Base Down operation
 type BaseLibcomposeOrchestrateDownParametrizedOperation struct {
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Provide static Properties for the operation
-func (base *BaseLibcomposeOrchestrateDownParametrizedOperation) Properties() *operation.Properties {
+func (base *BaseLibcomposeOrchestrateDownParametrizedOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 
-		newProperties.Add(operation.Property(&LibcomposeRemoveVolumesProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeRemoveImageTypeProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeRemoveOrphansProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeRemoveVolumesProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeRemoveImageTypeProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeRemoveOrphansProperty{}))
 
 		base.properties = newProperties
 	}
@@ -101,11 +101,11 @@ func (base *BaseLibcomposeOrchestrateDownParametrizedOperation) Properties() *op
 
 // LibCompose based down orchestrate operation
 type LibcomposeOrchestrateDownOperation struct {
-	orchestrate.BaseOrchestrationDownOperation
+	api_orchestrate.BaseOrchestrationDownOperation
 	BaseLibcomposeNameFilesOperation
 	BaseLibcomposeOrchestrateDownParametrizedOperation
 
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Validate the libCompose Orchestrate Down operation
@@ -114,9 +114,9 @@ func (down *LibcomposeOrchestrateDownOperation) Validate() bool {
 }
 
 // Provide static properties for the operation
-func (down *LibcomposeOrchestrateDownOperation) Properties() *operation.Properties {
+func (down *LibcomposeOrchestrateDownOperation) Properties() *api_operation.Properties {
 	if down.properties == nil {
-		down.properties = &operation.Properties{}
+		down.properties = &api_operation.Properties{}
 		down.properties.Merge(*down.BaseLibcomposeOrchestrateDownParametrizedOperation.Properties())
 		down.properties.Merge(*down.BaseLibcomposeNameFilesOperation.Properties())
 	}
@@ -124,8 +124,8 @@ func (down *LibcomposeOrchestrateDownOperation) Properties() *operation.Properti
 }
 
 // Execute the libCompose Orchestrate Down operation
-func (down *LibcomposeOrchestrateDownOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (down *LibcomposeOrchestrateDownOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 
 	properties := down.Properties()
 	// pass all props to make a project
@@ -158,5 +158,5 @@ func (down *LibcomposeOrchestrateDownOperation) Exec() operation.Result {
 		result.Set(false, []error{err})
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/libcompose/orchestrate_up.go
+++ b/libcompose/orchestrate_up.go
@@ -8,8 +8,8 @@ import (
 
 	libCompose_options "github.com/docker/libcompose/project/options"
 
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
 )
 
 /**
@@ -65,15 +65,15 @@ func (optionsConf *LibcomposeOptionsUpProperty) Set(value interface{}) bool {
 
 // Base Up operation
 type BaseLibcomposeOrchestrateUpSingleOperation struct {
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Provide static Properties for the operation
-func (base *BaseLibcomposeOrchestrateUpSingleOperation) Properties() *operation.Properties {
+func (base *BaseLibcomposeOrchestrateUpSingleOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 
-		newProperties.Add(operation.Property(&LibcomposeOptionsUpProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeOptionsUpProperty{}))
 
 		base.properties = newProperties
 	}
@@ -82,18 +82,18 @@ func (base *BaseLibcomposeOrchestrateUpSingleOperation) Properties() *operation.
 
 // Base Up operation
 type BaseLibcomposeOrchestrateUpParametrizedOperation struct {
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Provide static Properties for the operation
-func (base *BaseLibcomposeOrchestrateUpParametrizedOperation) Properties() *operation.Properties {
+func (base *BaseLibcomposeOrchestrateUpParametrizedOperation) Properties() *api_operation.Properties {
 	if base.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 
-		newProperties.Add(operation.Property(&LibcomposeNoRecreateProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeForceRecreateProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeNoBuildProperty{}))
-		newProperties.Add(operation.Property(&LibcomposeForceRebuildProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeNoRecreateProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeForceRecreateProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeNoBuildProperty{}))
+		newProperties.Add(api_operation.Property(&LibcomposeForceRebuildProperty{}))
 
 		base.properties = newProperties
 	}
@@ -102,11 +102,11 @@ func (base *BaseLibcomposeOrchestrateUpParametrizedOperation) Properties() *oper
 
 // LibCompose based up orchestrate operation
 type LibcomposeOrchestrateUpOperation struct {
-	orchestrate.BaseOrchestrationUpOperation
+	api_orchestrate.BaseOrchestrationUpOperation
 	BaseLibcomposeNameFilesOperation
 	BaseLibcomposeOrchestrateUpParametrizedOperation
 
-	properties *operation.Properties
+	properties *api_operation.Properties
 }
 
 // Validate the libCompose Orchestrate Up operation
@@ -115,9 +115,9 @@ func (up *LibcomposeOrchestrateUpOperation) Validate() bool {
 }
 
 // Provide static properties for the operation
-func (up *LibcomposeOrchestrateUpOperation) Properties() *operation.Properties {
+func (up *LibcomposeOrchestrateUpOperation) Properties() *api_operation.Properties {
 	if up.properties == nil {
-		newProperties := &operation.Properties{}
+		newProperties := &api_operation.Properties{}
 		newProperties.Merge(*up.BaseLibcomposeOrchestrateUpParametrizedOperation.Properties())
 		newProperties.Merge(*up.BaseLibcomposeNameFilesOperation.Properties())
 		up.properties = newProperties
@@ -126,8 +126,8 @@ func (up *LibcomposeOrchestrateUpOperation) Properties() *operation.Properties {
 }
 
 // Execute the libCompose Orchestrate Up operation
-func (up *LibcomposeOrchestrateUpOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (up *LibcomposeOrchestrateUpOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	properties := up.Properties()
@@ -166,5 +166,5 @@ func (up *LibcomposeOrchestrateUpOperation) Exec() operation.Result {
 		}
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/libcompose/property.go
+++ b/libcompose/property.go
@@ -3,7 +3,7 @@ package libcompose
 import (
 	// libCompose_options "github.com/docker/libcompose/project/options"
 
-	"github.com/james-nesbitt/kraut-api/operation"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
 )
 
 const (
@@ -57,7 +57,7 @@ const (
 
 // Project Name Property for a docker.libCompose project
 type LibcomposeProjectnameProperty struct {
-	operation.StringProperty
+	api_operation.StringProperty
 }
 
 // Id for the Property
@@ -82,7 +82,7 @@ func (name *LibcomposeProjectnameProperty) Internal() bool {
 
 // YAML file list Property for a docker.libCompose project
 type LibcomposeComposefilesProperty struct {
-	operation.StringSliceProperty
+	api_operation.StringSliceProperty
 }
 
 // Id for the Property
@@ -107,7 +107,7 @@ func (files *LibcomposeComposefilesProperty) Internal() bool {
 
 // A libcompose Property for net context limiting
 type LibcomposeContextProperty struct {
-	operation.ContextProperty
+	api_operation.ContextProperty
 }
 
 // Id for the Property
@@ -132,7 +132,7 @@ func (contextConf *LibcomposeContextProperty) Internal() bool {
 
 // Output handler Property for a docker.libCompose project
 type LibcomposeOutputProperty struct {
-	operation.WriterProperty
+	api_operation.WriterProperty
 }
 
 // Id for the Property
@@ -157,7 +157,7 @@ func (output *LibcomposeOutputProperty) Internal() bool {
 
 // Error handler Property for a docker.libCompose project
 type LibcomposeErrorProperty struct {
-	operation.WriterProperty
+	api_operation.WriterProperty
 }
 
 // Id for the Property
@@ -187,7 +187,7 @@ func (err *LibcomposeErrorProperty) Internal() bool {
 
 // BUILD : Property for a docker.libCompose project to indicate that a build should ignore cached image layers
 type LibcomposeNoCacheProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -212,7 +212,7 @@ func (nocache *LibcomposeNoCacheProperty) Internal() bool {
 
 // Property for a docker.libCompose project to indicate that a process remove ... something
 type LibcomposeForceRemoveProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -237,7 +237,7 @@ func (forceremove *LibcomposeForceRemoveProperty) Internal() bool {
 
 // Property for a docker.libCompose project to indicate that a process hsould stay attached and follow
 type LibcomposePullProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -262,7 +262,7 @@ func (pull *LibcomposePullProperty) Internal() bool {
 
 // Property for a docker.libCompose project to indicate that a process hsould stay attached and follow
 type LibcomposeDetachProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -287,7 +287,7 @@ func (detach *LibcomposeDetachProperty) Internal() bool {
 
 // UP : Property for a docker.libCompose project to indicate that a process should not create missing containers
 type LibcomposeNoRecreateProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -312,7 +312,7 @@ func (norecreate *LibcomposeNoRecreateProperty) Internal() bool {
 
 // UP|RECREATE : Property for a docker.libCompose project to indicate that a process should build containers even if they are found
 type LibcomposeForceRecreateProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -337,7 +337,7 @@ func (forcerecreate *LibcomposeForceRecreateProperty) Internal() bool {
 
 // UP|CREATE : Property for a docker.libCompose project to indicate that a process should not build any containers
 type LibcomposeNoBuildProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -362,7 +362,7 @@ func (dontbuild *LibcomposeNoBuildProperty) Internal() bool {
 
 // UP|CREATE : Property for a docker.libCompose project to indicate that a process should force rebuilding images
 type LibcomposeForceRebuildProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -387,7 +387,7 @@ func (forcerebuild *LibcomposeForceRebuildProperty) Internal() bool {
 
 // DOWN|DELETE : Property for a docker.libCompose project to indicate that a process should remove any volumes
 type LibcomposeRemoveVolumesProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -412,7 +412,7 @@ func (removevolumes *LibcomposeRemoveVolumesProperty) Internal() bool {
 
 // DOWN : Property for a docker.libCompose project to indicate that a process should remove any orphan containers
 type LibcomposeRemoveOrphansProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property
@@ -437,7 +437,7 @@ func (removeorphans *LibcomposeRemoveOrphansProperty) Internal() bool {
 
 // DOWN : Property for a docker.libCompose project to indicate that a process should remove images of a certain type
 type LibcomposeRemoveImageTypeProperty struct {
-	operation.StringProperty
+	api_operation.StringProperty
 }
 
 // Id for the Property
@@ -462,7 +462,7 @@ func (removeimagetypes *LibcomposeRemoveImageTypeProperty) Internal() bool {
 
 // DELETE : Property for a docker.libCompose project to indicate that a process should delete running containers
 type LibcomposeRemoveRunningProperty struct {
-	operation.BooleanProperty
+	api_operation.BooleanProperty
 }
 
 // Id for the Property

--- a/local/command.go
+++ b/local/command.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	"github.com/james-nesbitt/kraut-handlers/libcompose"
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/command"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_command "github.com/james-nesbitt/kraut-api/operation/command"
+	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
 )
 
 /**
@@ -14,7 +14,7 @@ import (
 type LocalHandler_Command struct {
 	LocalHandler_Base
 	LocalHandler_ConfigWrapperBase
-	libcompose.BaseLibcomposeHandler
+	handlers_libcompose.BaseLibcomposeHandler
 }
 
 // Identify the handler
@@ -23,27 +23,27 @@ func (handler *LocalHandler_Command) Id() string {
 }
 
 // [Handler.]Init tells the LocalHandler_Orchestrate to prepare it's operations
-func (handler *LocalHandler_Command) Init() operation.Result {
-	result := operation.BaseResult{}
+func (handler *LocalHandler_Command) Init() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
-	ops := operation.Operations{}
+	ops := api_operation.Operations{}
 
 	// Get shared base operation from the base handler
 	baseLibcompose := *handler.BaseLibcomposeHandler.LibComposeBaseOp
 
 	// Make a wrapper for the Command Config interpretation, based on itnerpreting YML settings
-	wrapper := libcompose.CommandConfigWrapper(libcompose.New_BaseCommandConfigWrapperYmlOperation(handler.ConfigWrapper()))
+	wrapper := handlers_libcompose.CommandConfigWrapper(handlers_libcompose.New_BaseCommandConfigWrapperYmlOperation(handler.ConfigWrapper()))
 
-	ops.Add(operation.Operation(&libcompose.LibcomposeCommandListOperation{BaseLibcomposeNameFilesOperation: baseLibcompose, Wrapper: wrapper}))
-	ops.Add(operation.Operation(&libcompose.LibcomposeCommandGetOperation{BaseLibcomposeNameFilesOperation: baseLibcompose, Wrapper: wrapper}))
+	ops.Add(api_operation.Operation(&handlers_libcompose.LibcomposeCommandListOperation{BaseLibcomposeNameFilesOperation: baseLibcompose, Wrapper: wrapper}))
+	ops.Add(api_operation.Operation(&handlers_libcompose.LibcomposeCommandGetOperation{BaseLibcomposeNameFilesOperation: baseLibcompose, Wrapper: wrapper}))
 
 	handler.operations = &ops
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 // Make OrchestrateWrapper
-func (handler *LocalHandler_Command) CommandWrapper() command.CommandWrapper {
-	return command.New_SimpleCommandWrapper(handler.operations)
+func (handler *LocalHandler_Command) CommandWrapper() api_command.CommandWrapper {
+	return api_command.New_SimpleCommandWrapper(handler.operations)
 }

--- a/local/config.go
+++ b/local/config.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	handlers_configconnect "github.com/james-nesbitt/kraut-handlers/configconnect"
 	api_operation "github.com/james-nesbitt/kraut-api/operation"
 	api_config "github.com/james-nesbitt/kraut-api/operation/config"
+	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"	
 )
 
 // A handler for local config
@@ -24,7 +24,7 @@ func (handler *LocalHandler_Config) Init() api_operation.Result {
 	ops := api_operation.Operations{}
 
 	// build a ConfigConnector for use with the Config operations.
-	connector := handlers_configconnect.New_ConfigConnectYmlFiles(handler.settings.ConfigPaths)
+	connector := handlers_bytesource.New_ConfigConnectYmlFiles(handler.settings.ConfigPaths)
 
 	// Build this base operation to be shared across all of our config operations
 	baseConnectorOperation := api_config.New_BaseConfigConnectorOperation(connector)

--- a/local/orchestrate.go
+++ b/local/orchestrate.go
@@ -1,16 +1,16 @@
 package local
 
 import (
-	"github.com/james-nesbitt/kraut-handlers/libcompose"
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_orchestrate "github.com/james-nesbitt/kraut-api/operation/orchestrate"
+	handlers_libcompose "github.com/james-nesbitt/kraut-handlers/libcompose"
 )
 
 // A handler for local orchestration using libcompose
 type LocalHandler_Orchestrate struct {
 	LocalHandler_Base
 	LocalHandler_SettingWrapperBase
-	libcompose.BaseLibcomposeHandler
+	handlers_libcompose.BaseLibcomposeHandler
 }
 
 // [Handler.]Id returns a string ID for the handler
@@ -19,26 +19,26 @@ func (handler *LocalHandler_Orchestrate) Id() string {
 }
 
 // [Handler.]Init tells the LocalHandler_Orchestrate to prepare it's operations
-func (handler *LocalHandler_Orchestrate) Init() operation.Result {
-	result := operation.BaseResult{}
+func (handler *LocalHandler_Orchestrate) Init() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
-	ops := operation.Operations{}
+	ops := api_operation.Operations{}
 
 	// Use discovered/default settings to build a base operation struct, to be share across orchestration operations
 	baseLibcompose := *handler.BaseLibcomposeHandler.LibComposeBaseOp
 
 	// Now we can add orchestration operations that use that Base class
-	ops.Add(operation.Operation(&libcompose.LibcomposeMonitorLogsOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
-	ops.Add(operation.Operation(&libcompose.LibcomposeOrchestrateUpOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
-	ops.Add(operation.Operation(&libcompose.LibcomposeOrchestrateDownOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
+	ops.Add(api_operation.Operation(&handlers_libcompose.LibcomposeMonitorLogsOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
+	ops.Add(api_operation.Operation(&handlers_libcompose.LibcomposeOrchestrateUpOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
+	ops.Add(api_operation.Operation(&handlers_libcompose.LibcomposeOrchestrateDownOperation{BaseLibcomposeNameFilesOperation: baseLibcompose}))
 
 	handler.operations = &ops
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 // Make OrchestrateWrapper
-func (handler *LocalHandler_Orchestrate) OrchestrateWrapper() orchestrate.OrchestrateWrapper {
-	return orchestrate.New_SimpleOrchestrateWrapper(handler.operations)
+func (handler *LocalHandler_Orchestrate) OrchestrateWrapper() api_orchestrate.OrchestrateWrapper {
+	return api_orchestrate.New_SimpleOrchestrateWrapper(handler.operations)
 }

--- a/local/project.go
+++ b/local/project.go
@@ -9,9 +9,9 @@ import (
 
 	jn_init "github.com/james-nesbitt/init-go"
 
-	"github.com/james-nesbitt/kraut-handlers/bytesource"
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/project"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_project "github.com/james-nesbitt/kraut-api/operation/project"
+	handlers_bytesource "github.com/james-nesbitt/kraut-handlers/bytesource"	
 )
 
 /**
@@ -29,20 +29,20 @@ func (handler *LocalHandler_Project) Id() string {
 }
 
 // [Handler.]Init tells the LocalHandler_Orchestrate to prepare it's operations
-func (handler *LocalHandler_Project) Init() operation.Result {
-	result := operation.BaseResult{}
+func (handler *LocalHandler_Project) Init() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
-	ops := operation.Operations{}
+	ops := api_operation.Operations{}
 
 	// Now we can add project operations that use that Base class
-	ops.Add(operation.Operation(&LocalProjectInitOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
-	ops.Add(operation.Operation(&LocalProjectCreateOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
-	ops.Add(operation.Operation(&LocalProjectGenerateOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
+	ops.Add(api_operation.Operation(&LocalProjectInitOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
+	ops.Add(api_operation.Operation(&LocalProjectCreateOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
+	ops.Add(api_operation.Operation(&LocalProjectGenerateOperation{fileSettings: handler.LocalHandler_Base.settings.BytesourceFileSettings}))
 
 	handler.operations = &ops
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 /**
@@ -50,11 +50,11 @@ func (handler *LocalHandler_Project) Init() operation.Result {
  */
 
 type LocalProjectInitOperation struct {
-	project.ProjectInitOperation
-	bytesource.BaseBytesourceFilesettingsOperation
+	api_project.ProjectInitOperation
+	handlers_bytesource.BaseBytesourceFilesettingsOperation
 
-	properties   *operation.Properties
-	fileSettings bytesource.BytesourceFileSettings
+	properties   *api_operation.Properties
+	fileSettings handlers_bytesource.BytesourceFileSettings
 }
 
 // Id the operation
@@ -64,7 +64,7 @@ func (init *LocalProjectInitOperation) Id() string {
 
 // Description for the LocalProjectCreateOperation
 func (init *LocalProjectInitOperation) Description() string {
-	return "Initialize the current project path as a kraut project."
+	return "Initialize the current project path as a kraut project"
 }
 
 // Validate the operation
@@ -74,15 +74,15 @@ func (init *LocalProjectInitOperation) Validate() bool {
 
 
 // Get properties
-func (init *LocalProjectInitOperation) Properties() *operation.Properties {
+func (init *LocalProjectInitOperation) Properties() *api_operation.Properties {
 	if init.properties == nil {
-		init.properties = &operation.Properties{}
+		init.properties = &api_operation.Properties{}
 
-		init.properties.Add(operation.Property(&project.ProjectInitDemoModeProperty{}))
+		init.properties.Add(api_operation.Property(&api_project.ProjectInitDemoModeProperty{}))
 
 		init.properties.Merge(*init.BaseBytesourceFilesettingsOperation.Properties())
 
-		if fileSettingsProp, exists := init.properties.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
+		if fileSettingsProp, exists := init.properties.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
 			fileSettingsProp.Set(init.fileSettings)
 		}
 	}
@@ -90,13 +90,13 @@ func (init *LocalProjectInitOperation) Properties() *operation.Properties {
 }
 
 // Execute the local project init operation
-func (init *LocalProjectInitOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (init *LocalProjectInitOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := init.Properties()
-	demoModeProp, _ := props.Get(project.OPERATION_PROPERTY_PROJECT_INIT_DEMOMODE)
-	settingsProp, _ := props.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
+	demoModeProp, _ := props.Get(api_project.OPERATION_PROPERTY_PROJECT_INIT_DEMOMODE)
+	settingsProp, _ := props.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
 
 	demoMode := demoModeProp.Get().(bool)
 
@@ -105,7 +105,7 @@ func (init *LocalProjectInitOperation) Exec() operation.Result {
 		source = "https://raw.githubusercontent.com/james-nesbitt/kraut-handlers/master/local/template/demo-init.yml"
 	}
 
-	settings := settingsProp.Get().(bytesource.BytesourceFileSettings)
+	settings := settingsProp.Get().(handlers_bytesource.BytesourceFileSettings)
 
 	log.WithFields(log.Fields{"source": source, "root": settings.ProjectRootPath}).Info("Running YML processer")
 
@@ -117,7 +117,7 @@ func (init *LocalProjectInitOperation) Exec() operation.Result {
 		tasks.RunTasks()
 	}	
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 /**
@@ -125,11 +125,11 @@ func (init *LocalProjectInitOperation) Exec() operation.Result {
  */
 
 type LocalProjectCreateOperation struct {
-	project.ProjectCreateOperation
-	bytesource.BaseBytesourceFilesettingsOperation
+	api_project.ProjectCreateOperation
+	handlers_bytesource.BaseBytesourceFilesettingsOperation
 
-	properties   *operation.Properties
-	fileSettings bytesource.BytesourceFileSettings
+	properties   *api_operation.Properties
+	fileSettings handlers_bytesource.BytesourceFileSettings
 }
 
 // Id the operation
@@ -148,16 +148,16 @@ func (create *LocalProjectCreateOperation) Validate() bool {
 }
 
 // Get properties
-func (create *LocalProjectCreateOperation) Properties() *operation.Properties {
+func (create *LocalProjectCreateOperation) Properties() *api_operation.Properties {
 	if create.properties == nil {
-		create.properties = &operation.Properties{}
+		create.properties = &api_operation.Properties{}
 
-		//create.properties.Add(operation.Property(&project.ProjectCreateTypeProperty{}))
-		create.properties.Add(operation.Property(&project.ProjectCreateSourceProperty{}))
+		//create.properties.Add(api_operation.Property(&api_project.ProjectCreateTypeProperty{}))
+		create.properties.Add(api_operation.Property(&api_project.ProjectCreateSourceProperty{}))
 
 		create.properties.Merge(*create.BaseBytesourceFilesettingsOperation.Properties())
 
-		if fileSettingsProp, exists := create.properties.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
+		if fileSettingsProp, exists := create.properties.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
 			fileSettingsProp.Set(create.fileSettings)
 		}
 	}
@@ -165,17 +165,17 @@ func (create *LocalProjectCreateOperation) Properties() *operation.Properties {
 }
 
 // Execute the local project init operation
-func (create *LocalProjectCreateOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (create *LocalProjectCreateOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := create.Properties()
-	//typeProp, _ := props.Get(project.OPERATION_PROPERTY_PROJECT_CREATE_TYPE)
-	sourceProp, _ := props.Get(project.OPERATION_PROPERTY_PROJECT_CREATE_SOURCE)
-	settingsProp, _ := props.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
+	//typeProp, _ := props.Get(api_project.OPERATION_PROPERTY_PROJECT_CREATE_TYPE)
+	sourceProp, _ := props.Get(api_project.OPERATION_PROPERTY_PROJECT_CREATE_SOURCE)
+	settingsProp, _ := props.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
 
 	source := sourceProp.Get().(string)
-	settings := settingsProp.Get().(bytesource.BytesourceFileSettings)
+	settings := settingsProp.Get().(handlers_bytesource.BytesourceFileSettings)
 
 	log.WithFields(log.Fields{"source": source, "root": settings.ProjectRootPath}).Info("Running YML processer")
 
@@ -187,7 +187,7 @@ func (create *LocalProjectCreateOperation) Exec() operation.Result {
 		tasks.RunTasks()
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 /**
@@ -195,11 +195,11 @@ func (create *LocalProjectCreateOperation) Exec() operation.Result {
  */
 
 type LocalProjectGenerateOperation struct {
-	project.ProjectGenerateOperation
-	bytesource.BaseBytesourceFilesettingsOperation
+	api_project.ProjectGenerateOperation
+	handlers_bytesource.BaseBytesourceFilesettingsOperation
 
-	properties   *operation.Properties
-	fileSettings bytesource.BytesourceFileSettings
+	properties   *api_operation.Properties
+	fileSettings handlers_bytesource.BytesourceFileSettings
 }
 
 // Id the operation
@@ -209,7 +209,7 @@ func (generate *LocalProjectGenerateOperation) Id() string {
 
 // Description for the LocalProjectCreateOperation
 func (generate *LocalProjectGenerateOperation) Description() string {
-	return "Create a yml template from the current project."
+	return "Create a yml template from the current project"
 }
 
 // Validate the operation
@@ -218,15 +218,15 @@ func (generate *LocalProjectGenerateOperation) Validate() bool {
 }
 
 // Get properties
-func (generate *LocalProjectGenerateOperation) Properties() *operation.Properties {
+func (generate *LocalProjectGenerateOperation) Properties() *api_operation.Properties {
 	if generate.properties == nil {
-		generate.properties = &operation.Properties{}
+		generate.properties = &api_operation.Properties{}
 
-		//generate.properties.Add(operation.Property(&project.ProjectCreateTypeProperty{}))
+		//generate.properties.Add(api_operation.Property(&api_project.ProjectCreateTypeProperty{}))
 
 		generate.properties.Merge(*generate.BaseBytesourceFilesettingsOperation.Properties())
 
-		if fileSettingsProp, exists := generate.properties.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
+		if fileSettingsProp, exists := generate.properties.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS); exists {
 			fileSettingsProp.Set(generate.fileSettings)
 		}
 	}
@@ -234,15 +234,15 @@ func (generate *LocalProjectGenerateOperation) Properties() *operation.Propertie
 }
 
 // Execute the local project init operation
-func (generate *LocalProjectGenerateOperation) Exec() operation.Result {
-	result := operation.BaseResult{}
+func (generate *LocalProjectGenerateOperation) Exec() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
 	props := generate.Properties()
-	//typeProp, _ := props.Get(project.OPERATION_PROPERTY_PROJECT_CREATE_TYPE)
-	settingsProp, _ := props.Get(bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
+	//typeProp, _ := props.Get(api_project.OPERATION_PROPERTY_PROJECT_CREATE_TYPE)
+	settingsProp, _ := props.Get(handlers_bytesource.OPERATION_PROPERTY_BYTESOURCE_FILESETTINGS)
 
-	settings := settingsProp.Get().(bytesource.BytesourceFileSettings)
+	settings := settingsProp.Get().(handlers_bytesource.BytesourceFileSettings)
 
 	var method string = "yaml"
 	var writer io.Writer
@@ -281,5 +281,5 @@ func (generate *LocalProjectGenerateOperation) Exec() operation.Result {
 		}
 	}
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }

--- a/local/setting.go
+++ b/local/setting.go
@@ -1,9 +1,9 @@
 package local
 
 import (
-	"github.com/james-nesbitt/kraut-handlers/configconnect"
-	"github.com/james-nesbitt/kraut-api/operation"
-	"github.com/james-nesbitt/kraut-api/operation/setting"
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+	api_setting "github.com/james-nesbitt/kraut-api/operation/setting"
+	handlers_configwrapper "github.com/james-nesbitt/kraut-handlers/configwrapper"	
 )
 
 // A handler for local settings
@@ -18,26 +18,26 @@ func (handler *LocalHandler_Setting) Id() string {
 }
 
 // [Handler.]Init tells the LocalHandler_Orchestrate to prepare it's operations
-func (handler *LocalHandler_Setting) Init() operation.Result {
-	result := operation.BaseResult{}
+func (handler *LocalHandler_Setting) Init() api_operation.Result {
+	result := api_operation.BaseResult{}
 	result.Set(true, nil)
 
-	ops := operation.Operations{}
+	ops := api_operation.Operations{}
 
 	// Make a wrapper for the Settings Config interpretation, based on itnerpreting YML settings
-	wrapper := configconnect.SettingsConfigWrapper(configconnect.New_BaseSettingConfigWrapperYmlOperation(handler.ConfigWrapper()))
+	wrapper := handlers_configwrapper.SettingsConfigWrapper(handlers_configwrapper.New_BaseSettingConfigWrapperYmlOperation(handler.ConfigWrapper()))
 
 	// Now we can add config operations that use that Base class
-	ops.Add(operation.Operation(&configconnect.SettingConfigWrapperGetOperation{Wrapper: wrapper}))
-	ops.Add(operation.Operation(&configconnect.SettingConfigWrapperSetOperation{Wrapper: wrapper}))
-	ops.Add(operation.Operation(&configconnect.SettingConfigWrapperListOperation{Wrapper: wrapper}))
+	ops.Add(api_operation.Operation(&handlers_configwrapper.SettingConfigWrapperGetOperation{Wrapper: wrapper}))
+	ops.Add(api_operation.Operation(&handlers_configwrapper.SettingConfigWrapperSetOperation{Wrapper: wrapper}))
+	ops.Add(api_operation.Operation(&handlers_configwrapper.SettingConfigWrapperListOperation{Wrapper: wrapper}))
 
 	handler.operations = &ops
 
-	return operation.Result(&result)
+	return api_operation.Result(&result)
 }
 
 // Make ConfigWrapper
-func (handler *LocalHandler_Setting) SettingWrapper() setting.SettingWrapper {
-	return setting.New_SimpleSettingWrapper(handler.operations)
+func (handler *LocalHandler_Setting) SettingWrapper() api_setting.SettingWrapper {
+	return api_setting.New_SimpleSettingWrapper(handler.operations)
 }


### PR DESCRIPTION
This large patch primarily just adopts a convention for importing Go libraries from the kraut api between handlers.

There is a small rename of the configconnect handler to configwrapper, and the file_configwrapper generator was moved to the bytesource handler.

This change will impact the CLI which may need to change a single line of code.