### PR TITLE
better upcloud settings and operation filters

### DIFF
--- a/upcloud/base.go
+++ b/upcloud/base.go
@@ -1,20 +1,42 @@
 package upcloud
 
+import (
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+)
+
+/**
+ * Some base structs which other UpCloud Handler and
+ * Operation implementations can include
+ */
+
 // Constructor for BaseUpcloudServiceHandler
-func New_BaseUpcloudServiceHandler(service *UpcloudServiceWrapper) *BaseUpcloudServiceHandler {
+func New_BaseUpcloudServiceHandler(service *UpcloudServiceWrapper, settings *UpcloudBuilderSettings) *BaseUpcloudServiceHandler {
 	return &BaseUpcloudServiceHandler{
-		service: service,
+		service:  service,
+		settings: settings,
 	}
 }
 
 // Base handler with an upcloud service
 type BaseUpcloudServiceHandler struct {
-	service *UpcloudServiceWrapper
+	service    *UpcloudServiceWrapper
+	settings   *UpcloudBuilderSettings
+	operations *api_operation.Operations
 }
 
-// Set the service
+// Return the stored operatons
+func (base *BaseUpcloudServiceHandler) Operations() *api_operation.Operations {
+	return base.operations
+}
+
+// Get the service
 func (base *BaseUpcloudServiceHandler) ServiceWrapper() *UpcloudServiceWrapper {
 	return base.service
+}
+
+// Get the settings
+func (base *BaseUpcloudServiceHandler) Settings() *UpcloudBuilderSettings {
+	return base.settings
 }
 
 /**
@@ -23,18 +45,25 @@ func (base *BaseUpcloudServiceHandler) ServiceWrapper() *UpcloudServiceWrapper {
  */
 
 // Constructor for BaseUpcloudServiceOperation
-func New_BaseUpcloudServiceOperation(service *UpcloudServiceWrapper) *BaseUpcloudServiceOperation {
+func New_BaseUpcloudServiceOperation(service *UpcloudServiceWrapper, settings *UpcloudBuilderSettings) *BaseUpcloudServiceOperation {
 	return &BaseUpcloudServiceOperation{
-		service: service,
+		service:  service,
+		settings: settings,
 	}
 }
 
 // Base operation with an upcloud service
 type BaseUpcloudServiceOperation struct {
-	service *UpcloudServiceWrapper
+	service  *UpcloudServiceWrapper
+	settings *UpcloudBuilderSettings
 }
 
 // Set the service
 func (base *BaseUpcloudServiceOperation) ServiceWrapper() *UpcloudServiceWrapper {
 	return base.service
+}
+
+// Get the settings
+func (base *BaseUpcloudServiceOperation) Settings() *UpcloudBuilderSettings {
+	return base.settings
 }

--- a/upcloud/client.go
+++ b/upcloud/client.go
@@ -4,19 +4,18 @@ import (
 	upcloud_client "github.com/Jalle19/upcloud-go-sdk/upcloud/client"
 )
 
-
 // Constructor for UpcloudClientSettings
 func New_UpcloudClientSettings(user string, password string) *UpcloudClientSettings {
 	return &UpcloudClientSettings{
-		user: user,
+		user:     user,
 		password: password,
 	}
 }
 
 // Client Settings property
 type UpcloudClientSettings struct {
-	user string
-	password string  // don't make this public
+	user     string
+	password string // don't make this public
 }
 
 // Builder an UpCloud client from the settings

--- a/upcloud/factory.go
+++ b/upcloud/factory.go
@@ -8,4 +8,3 @@ const (
 type UpcloudFactory interface {
 	ServiceWrapper() *UpcloudServiceWrapper
 }
-

--- a/upcloud/factory_configyml.go
+++ b/upcloud/factory_configyml.go
@@ -25,15 +25,14 @@ import (
 func New_UpcloudFactoryConfigWrapperYaml(configWrapper api_config.ConfigWrapper) UpcloudFactory {
 	return UpcloudFactory(&UpcloudFactoryConfigWrapperYaml{
 		configWrapper: configWrapper,
-		ymlFactory: Yml_UpcloudFactory{},
+		ymlFactory:    Yml_UpcloudFactory{},
 	})
 }
-
 
 // A BuilderSettingsConfigWrapper, that interprets build config as yml
 type UpcloudFactoryConfigWrapperYaml struct {
 	configWrapper api_config.ConfigWrapper
-	ymlFactory Yml_UpcloudFactory
+	ymlFactory    Yml_UpcloudFactory
 }
 
 func (configFactory *UpcloudFactoryConfigWrapperYaml) DefaultScope() string {
@@ -47,7 +46,7 @@ func (configFactory *UpcloudFactoryConfigWrapperYaml) DefaultScope() string {
 func (configFactory *UpcloudFactoryConfigWrapperYaml) safe() {
 	if configFactory.ymlFactory.Empty() {
 		if err := configFactory.Load(); err != nil {
-			log.WithError(err).Error("Could not load build configuration")			
+			log.WithError(err).Error("Could not load build configuration")
 		}
 	}
 }
@@ -57,11 +56,13 @@ func (configFactory *UpcloudFactoryConfigWrapperYaml) Client() *upcloud_client.C
 	configFactory.safe()
 	return configFactory.ymlFactory.MakeClient()
 }
+
 // Convert this YML struct into a Service
 func (configFactory *UpcloudFactoryConfigWrapperYaml) Service() *upcloud_service.Service {
 	configFactory.safe()
 	return configFactory.ymlFactory.MakeService()
 }
+
 // Convert this YML struct into a ServiceWrapper
 func (configFactory *UpcloudFactoryConfigWrapperYaml) ServiceWrapper() *UpcloudServiceWrapper {
 	configFactory.safe()
@@ -97,7 +98,7 @@ func (configFactory *UpcloudFactoryConfigWrapperYaml) Load() error {
 func (configFactory *UpcloudFactoryConfigWrapperYaml) Save() error {
 	/**
 	 * @TODO THIS
-     */
+	 */
 	return errors.New("UpcloudFactoryConfigWrapperYaml Set operation not yet written.")
 }
 
@@ -105,22 +106,26 @@ func (configFactory *UpcloudFactoryConfigWrapperYaml) Save() error {
 type Yml_UpcloudFactory struct {
 	scope string
 
-	User string 				`yaml:"User"`
-	Password string 	        `yaml:"Password"`
+	User     string `yaml:"User"`
+	Password string `yaml:"Password"`
 }
+
 // Is this struct populated?
 func (ymlFactory *Yml_UpcloudFactory) Empty() bool {
 	return ymlFactory.User == ""
 }
+
 // Convert this YML struct into a Client
 func (ymlFactory *Yml_UpcloudFactory) MakeClient() *upcloud_client.Client {
 	return New_UpcloudClientSettings(ymlFactory.User, ymlFactory.Password).Client()
 }
+
 // Convert this YML struct into a Service
 func (ymlFactory *Yml_UpcloudFactory) MakeService() *upcloud_service.Service {
 	client := ymlFactory.MakeClient()
 	return New_UpcloudServiceSettings(*client).Service()
 }
+
 // Convert this YML struct into a Service
 func (ymlFactory *Yml_UpcloudFactory) MakeServiceWrapper() *UpcloudServiceWrapper {
 	client := ymlFactory.MakeClient()

--- a/upcloud/monitor.go
+++ b/upcloud/monitor.go
@@ -5,9 +5,10 @@ import (
 
 	api_operation "github.com/james-nesbitt/kraut-api/operation"
 )
+
 /**
  * Monitor handler for Upcloud operations
- */ 
+ */
 type UpcloudMonitorHandler struct {
 	BaseUpcloudServiceHandler
 }
@@ -16,23 +17,23 @@ type UpcloudMonitorHandler struct {
 func (monitor *UpcloudMonitorHandler) Init() api_operation.Result {
 	result := api_operation.BaseResult{}
 	result.Set(true, []error{})
-	return api_operation.Result(&result)
-}
-// Rturn a string identifier for the Handler (not functionally needed yet)
-func (monitor *UpcloudMonitorHandler) Id() string {
-	return "upcloud.monitor"
-}
-// Return a list of Operations from the Handler
-func (monitor *UpcloudMonitorHandler) Operations() *api_operation.Operations {
+
 	ops := api_operation.Operations{}
 
-	baseOperation := New_BaseUpcloudServiceOperation(monitor.ServiceWrapper())
+	baseOperation := New_BaseUpcloudServiceOperation(monitor.ServiceWrapper(), monitor.Settings())
 
 	ops.Add(api_operation.Operation(&UpcloudMonitorShowAccountOperation{BaseUpcloudServiceOperation: *baseOperation}))
 	ops.Add(api_operation.Operation(&UpcloudMonitorListZonesOperation{BaseUpcloudServiceOperation: *baseOperation}))
 	ops.Add(api_operation.Operation(&UpcloudMonitorListServersOperation{BaseUpcloudServiceOperation: *baseOperation}))
 
-	return &ops
+	monitor.operations = &ops
+
+	return api_operation.Result(&result)
+}
+
+// Rturn a string identifier for the Handler (not functionally needed yet)
+func (monitor *UpcloudMonitorHandler) Id() string {
+	return "upcloud.monitor"
 }
 
 /**
@@ -41,14 +42,17 @@ func (monitor *UpcloudMonitorHandler) Operations() *api_operation.Operations {
 type UpcloudMonitorShowAccountOperation struct {
 	BaseUpcloudServiceOperation
 }
+
 // Return the string machinename/id of the Operation
 func (showAccount *UpcloudMonitorShowAccountOperation) Id() string {
 	return "upcloud.monitor.account"
 }
+
 // Return a user readable string label for the Operation
 func (showAccount *UpcloudMonitorShowAccountOperation) Label() string {
 	return "Show UpCloud Account information"
 }
+
 // return a multiline string description for the Operation
 func (showAccount *UpcloudMonitorShowAccountOperation) Description() string {
 	return "Show information about the current UpCloud account."
@@ -95,17 +99,21 @@ func (showAccount *UpcloudMonitorShowAccountOperation) Exec() api_operation.Resu
  */
 type UpcloudMonitorListZonesOperation struct {
 	BaseUpcloudServiceOperation
+	properties *api_operation.Properties
 }
+
 // Return the string machinename/id of the Operation
 func (listZones *UpcloudMonitorListZonesOperation) Id() string {
 	return "upcloud.monitor.list.zones"
 }
+
 // Return a user readable string label for the Operation
 func (listZones *UpcloudMonitorListZonesOperation) Label() string {
 	return "List UpCloud Zones"
 }
+
 // return a multiline string description for the Operation
-func (listZones *UpcloudMonitorListZonesOperation)Description() string {
+func (listZones *UpcloudMonitorListZonesOperation) Description() string {
 	return "List information about the UpCloud zones."
 }
 
@@ -114,7 +122,6 @@ func (listZones *UpcloudMonitorListZonesOperation) Internal() bool {
 	return false
 }
 
-
 // Run a validation check on the Operation
 func (listZones *UpcloudMonitorListZonesOperation) Validate() bool {
 	return true
@@ -122,9 +129,15 @@ func (listZones *UpcloudMonitorListZonesOperation) Validate() bool {
 
 // What settings/values does the Operation provide to an implemenentor
 func (listZones *UpcloudMonitorListZonesOperation) Properties() *api_operation.Properties {
-	props := api_operation.Properties{}
+	if listZones.properties == nil {
+		props := api_operation.Properties{}
 
-	return &props
+		props.Add(api_operation.Property(&UpcloudGlobalProperty{}))
+		props.Add(api_operation.Property(&UpcloudZoneIdProperty{}))
+
+		listZones.properties = &props
+	}
+	return listZones.properties
 }
 
 // Execute the Operation
@@ -133,11 +146,45 @@ func (listZones *UpcloudMonitorListZonesOperation) Exec() api_operation.Result {
 	result.Set(true, []error{})
 
 	service := listZones.ServiceWrapper()
+	settings := listZones.Settings()
+
+	global := false
+	properties := listZones.Properties()
+	if globalProp, found := properties.Get(UPCLOUD_GLOBAL_PROPERTY); found {
+		global = globalProp.Get().(bool)
+		log.WithFields(log.Fields{"key": UPCLOUD_GLOBAL_PROPERTY, "prop": globalProp, "value": global}).Debug("Filter: global")
+	}
+	idMatch := []string{}
+	if idProp, found := properties.Get(UPCLOUD_ZONE_ID_PROPERTY); found {
+		ids := idProp.Get().([]string)
+		idMatch = append(idMatch, ids...)
+		log.WithFields(log.Fields{"key": UPCLOUD_ZONE_ID_PROPERTY, "prop": idProp, "value": idMatch}).Debug("Filter: zone id")
+	}
 
 	zones, err := service.GetZones()
 	if err == nil {
-		for index,zone := range zones.Zones {
-			log.WithFields(log.Fields{"index": index, "id": zone.Id, "description": zone.Description}).Info("UpCloud zone")
+		for index, zone := range zones.Zones {
+			filterOut := false
+
+			// filter out zones that are no a part of the current project
+			if !global {
+				filterOut = !settings.ZoneAllowed(zone)
+			}
+
+			// if some server filters were passed, filter out anything not in the passed list
+			if len(idMatch) > 0 {
+				found := false
+				for _, id := range idMatch {
+					if id == zone.Id {
+						found = true
+					}
+				}
+				filterOut = !found
+			}
+
+			if !filterOut {
+				log.WithFields(log.Fields{"index": index, "id": zone.Id, "description": zone.Description}).Info("UpCloud zone")
+			}
 		}
 	} else {
 		log.WithError(err).Error("Could not retrieve UpCloud zones information.")
@@ -151,51 +198,95 @@ func (listZones *UpcloudMonitorListZonesOperation) Exec() api_operation.Result {
  */
 type UpcloudMonitorListServersOperation struct {
 	BaseUpcloudServiceOperation
+	properties *api_operation.Properties
 }
+
 // Return the string machinename/id of the Operation
-func (list *UpcloudMonitorListServersOperation) Id() string {
+func (listServers *UpcloudMonitorListServersOperation) Id() string {
 	return "upcloud.monitor.list.servers"
 }
+
 // Return a user readable string label for the Operation
-func (list *UpcloudMonitorListServersOperation) Label() string {
+func (listServers *UpcloudMonitorListServersOperation) Label() string {
 	return "UpCloud server list"
 }
+
 // return a multiline string description for the Operation
-func (list *UpcloudMonitorListServersOperation) Description() string {
+func (listServers *UpcloudMonitorListServersOperation) Description() string {
 	return "List UpCloud servers used in the project"
 }
 
 // Is this operation meant to be used only inside the API
-func (list *UpcloudMonitorListServersOperation) Internal() bool {
+func (listServers *UpcloudMonitorListServersOperation) Internal() bool {
 	return false
 }
 
 // Run a validation check on the Operation
-func (list *UpcloudMonitorListServersOperation) Validate() bool {
+func (listServers *UpcloudMonitorListServersOperation) Validate() bool {
 	return true
 }
 
 // What settings/values does the Operation provide to an implemenentor
-func (list *UpcloudMonitorListServersOperation) Properties() *api_operation.Properties {
-	props := api_operation.Properties{}
+func (listServers *UpcloudMonitorListServersOperation) Properties() *api_operation.Properties {
+	if listServers.properties == nil {
+		props := api_operation.Properties{}
 
-	return &props
+		props.Add(api_operation.Property(&UpcloudGlobalProperty{}))
+		props.Add(api_operation.Property(&UpcloudServerUUIDProperty{}))
+
+		listServers.properties = &props
+	}
+	return listServers.properties
 }
 
 // Execute the Operation
-func (list *UpcloudMonitorListServersOperation) Exec() api_operation.Result {
+func (listServers *UpcloudMonitorListServersOperation) Exec() api_operation.Result {
 	result := api_operation.BaseResult{}
 	result.Set(true, []error{})
 
-	service := list.ServiceWrapper()
+	service := listServers.ServiceWrapper()
+	settings := listServers.Settings()
+
+	global := false
+	properties := listServers.Properties()
+	if globalProp, found := properties.Get(UPCLOUD_GLOBAL_PROPERTY); found {
+		global = globalProp.Get().(bool)
+		log.WithFields(log.Fields{"key": UPCLOUD_GLOBAL_PROPERTY, "prop": globalProp, "value": global}).Debug("GLOBAL")
+	}
+	uuidMatch := []string{}
+	if uuidProp, found := properties.Get(UPCLOUD_SERVER_UUID_PROPERTY); found {
+		newUUIDs := uuidProp.Get().([]string)
+		uuidMatch = append(uuidMatch, newUUIDs...)
+		log.WithFields(log.Fields{"key": UPCLOUD_SERVER_UUID_PROPERTY, "prop": uuidMatch, "value": uuidMatch}).Debug("Filter: Server UUID")
+	}
 
 	servers, err := service.GetServers()
 	if err == nil {
 		for index, server := range servers.Servers {
-			log.WithFields(log.Fields{"index": index, "uuid": server.UUID, "title": server.Title, "plan": server.Plan, "zone": server.Zone}).Info("Server")
+			filterOut := false
+
+			// filter out servers that are no a part of the current project
+			if !global {
+				filterOut = !settings.ServerAllowed(server)
+			}
+
+			// if some server filters were passed, filter out anything not in the passed list
+			if len(uuidMatch) > 0 {
+				found := false
+				for _, uuid := range uuidMatch {
+					if uuid == server.UUID {
+						found = true
+					}
+				}
+				filterOut = !found
+			}
+
+			if !filterOut {
+				log.WithFields(log.Fields{"index": index, "uuid": server.UUID, "title": server.Title, "plan": server.Plan, "zone": server.Zone}).Info("Server")
+			}
 		}
 	} else {
-		log.WithError(err).Error("Could not list UpCloud servers")		
+		log.WithError(err).Error("Could not list UpCloud servers")
 	}
 
 	return api_operation.Result(&result)

--- a/upcloud/property.go
+++ b/upcloud/property.go
@@ -1,5 +1,91 @@
 package upcloud
 
+import (
+	api_operation "github.com/james-nesbitt/kraut-api/operation"
+)
+
 /**
  * Custom properties for the upcloud operations
  */
+
+const (
+	UPCLOUD_GLOBAL_PROPERTY      = "upcloud.global"
+	UPCLOUD_SERVER_UUID_PROPERTY = "upcloud.server.uuid"
+	UPCLOUD_ZONE_ID_PROPERTY     = "upcloud.zone.id"
+)
+
+// A boolean flag that tells upcloud to consider services/zones outside the scope of the project
+// @NOTE this is kind of risky to use, so it should be limited to safe operations
+type UpcloudGlobalProperty struct {
+	api_operation.BooleanProperty
+}
+
+// ID returns string unique property Identifier
+func (global *UpcloudGlobalProperty) Id() string {
+	return UPCLOUD_GLOBAL_PROPERTY
+}
+
+// Label returns a short user readable label for the property
+func (global *UpcloudGlobalProperty) Label() string {
+	return "Global UpCloud services"
+}
+
+// Description provides a longer multi-line string description of what the property does
+func (global *UpcloudGlobalProperty) Description() string {
+	return "Consider UpCloud Service/Zones outside the scope of the project"
+}
+
+// Mark a property as being for internal use only (no shown to users)
+func (global *UpcloudGlobalProperty) Internal() bool {
+	return false
+}
+
+// A string slice property to match to server UUID
+type UpcloudServerUUIDProperty struct {
+	api_operation.StringSliceProperty
+}
+
+// ID returns string unique property Identifier
+func (uuid *UpcloudServerUUIDProperty) Id() string {
+	return UPCLOUD_SERVER_UUID_PROPERTY
+}
+
+// Label returns a short user readable label for the property
+func (uuid *UpcloudServerUUIDProperty) Label() string {
+	return "UpCloud server UUID"
+}
+
+// Description provides a longer multi-line string description of what the property does
+func (uuid *UpcloudServerUUIDProperty) Description() string {
+	return "Specific UpCloud server UUID"
+}
+
+// Mark a property as being for internal use only (no shown to users)
+func (uuid *UpcloudServerUUIDProperty) Internal() bool {
+	return false
+}
+
+// A string slice property to match to zone id
+type UpcloudZoneIdProperty struct {
+	api_operation.StringSliceProperty
+}
+
+// ID returns string unique property Identifier
+func (id *UpcloudZoneIdProperty) Id() string {
+	return UPCLOUD_ZONE_ID_PROPERTY
+}
+
+// Label returns a short user readable label for the property
+func (id *UpcloudZoneIdProperty) Label() string {
+	return "UpCloud zone ID"
+}
+
+// Description provides a longer multi-line string description of what the property does
+func (id *UpcloudZoneIdProperty) Description() string {
+	return "Specific UpCloud zone ID"
+}
+
+// Mark a property as being for internal use only (no shown to users)
+func (id *UpcloudZoneIdProperty) Internal() bool {
+	return false
+}

--- a/upcloud/service.go
+++ b/upcloud/service.go
@@ -3,6 +3,7 @@ package upcloud
 import (
 	log "github.com/Sirupsen/logrus"
 
+	upcloud "github.com/Jalle19/upcloud-go-sdk/upcloud"
 	upcloud_client "github.com/Jalle19/upcloud-go-sdk/upcloud/client"
 	upcloud_service "github.com/Jalle19/upcloud-go-sdk/upcloud/service"
 )
@@ -18,10 +19,11 @@ func New_UpcloudServiceSettings(client upcloud_client.Client) *UpcloudServiceSet
 	}
 }
 
-// Settings for the 
+// Settings for the
 type UpcloudServiceSettings struct {
 	client upcloud_client.Client
 }
+
 // Get an Upcloud service from these settings
 func (serviceSettings UpcloudServiceSettings) Service() *upcloud_service.Service {
 	return New_UpcloudServiceFromClient(serviceSettings.client)
@@ -33,13 +35,11 @@ func (serviceSettings UpcloudServiceSettings) ServiceWrapper() *UpcloudServiceWr
 	return New_UpcloudServiceWrapper(*service)
 }
 
-
 // Constructor for upcloud Service from a client
 func New_UpcloudServiceFromClient(client upcloud_client.Client) *upcloud_service.Service {
 	service := upcloud_service.New(&client)
 	return service
 }
-
 
 // Constructor for UpcloudServiceWrapper
 func New_UpcloudServiceWrapper(service upcloud_service.Service) *UpcloudServiceWrapper {
@@ -48,11 +48,13 @@ func New_UpcloudServiceWrapper(service upcloud_service.Service) *UpcloudServiceW
 	}
 }
 
-
 // Define some values that can be used by the ServiceWrapper to limit and configure it
 type UpcloudBuilderSettings struct {
-	Hosts []string  `yml:"Hosts"`
+	Hosts  []string `yml:"Hosts"`
+	Labels []string `yml:"Labels"`
+	Zones  []string `yml:"Zones"`
 }
+
 // Merge settings
 func (settings *UpcloudBuilderSettings) Merge(merge UpcloudBuilderSettings) {
 	// merge hosts
@@ -71,6 +73,7 @@ func (settings *UpcloudBuilderSettings) Merge(merge UpcloudBuilderSettings) {
 
 	log.WithFields(log.Fields{"settings": settings}).Debug("Merged UpCloud settings")
 }
+
 // It doesn't want to automatically marshal, so do it manually @TODO why isn't it unmarshalling automatically?
 func (settings *UpcloudBuilderSettings) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	placeholder := map[string][]string{}
@@ -92,11 +95,60 @@ func (settings *UpcloudBuilderSettings) UnmarshalYAML(unmarshal func(interface{}
 			}
 		}
 	}
+	if labels, defined := placeholder["Labels"]; defined {
+		for _, label := range labels {
+			exists := false
+			for _, existing := range settings.Labels {
+				if existing == label {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				settings.Labels = append(settings.Labels, label)
+			}
+		}
+	}
+	if zones, defined := placeholder["Zones"]; defined {
+		for _, zone := range zones {
+			exists := false
+			for _, existing := range settings.Zones {
+				if existing == zone {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				settings.Zones = append(settings.Zones, zone)
+			}
+		}
+	}
 	return nil
+}
+
+// Does this server match settings from the BuilderSettings (is it in this project)
+func (settings *UpcloudBuilderSettings) ServerAllowed(server upcloud.Server) bool {
+	// simple host UUID match
+	for _, match := range settings.Hosts {
+		if match == server.UUID {
+			return true
+		}
+	}
+	return false
+}
+
+// Does this server match settings from the BuilderSettings (is it in this project)
+func (settings *UpcloudBuilderSettings) ZoneAllowed(zone upcloud.Zone) bool {
+	// simple host UUID match
+	for _, match := range settings.Zones {
+		if match == zone.Id {
+			return true
+		}
+	}
+	return false
 }
 
 // Wrapper for the upcloud service, so that we can limit operations
 type UpcloudServiceWrapper struct {
 	upcloud_service.Service
-
 }


### PR DESCRIPTION
The UpCloud handler now accepts zone and server-label filters, and the operations default to filtering to the current project assets, unless a global options is passed.