### PR TITLE
fix command services by adding default networks to config

### DIFF
--- a/libcompose/servicealter.go
+++ b/libcompose/servicealter.go
@@ -14,13 +14,44 @@ import (
 	"strings"
 
 	libCompose_config "github.com/docker/libcompose/config"
+	libCompose_yaml "github.com/docker/libcompose/yaml"
 )
 
 /**
  * clean up a service based on this app
  */
 func (project *ComposeProject) AlterService(service *libCompose_config.ServiceConfig) {
+	project.alterService_ProjectNetwork(service)
 	project.alterService_RewriteMappedVolumes(service)
+}
+
+// make sure that a service is using the default network [@TODO THIS SHOULD NOT BE NECESSARY]
+func (project *ComposeProject) alterService_ProjectNetwork(service *libCompose_config.ServiceConfig) {
+	/**
+	 * If a service has no network then we create the default network config.
+	 *
+	 * This is copypasta from github.com/docker/libcompose/project::Project.handleNetworkConfig()
+	 * which means that we are duplicating internal functionality that may not be stable.
+	 *
+	 * This requirement came up after an update to the libcompose upstream library, which broke
+	 * the existing missing network setup.  What is happening is that we are alteting a serviceconfig
+	 * which will be added to a libcompose.Project::Project struct, and that struct has already 
+	 * run its initializer, which does the default network configuration.  This means that it is
+	 * too late to simply add an empty network.  An alternative is to re-run the initializer, but
+	 * as we have no access to that functionality from the Interface, there is little we can do.
+	 */
+
+	if service.Networks == nil || len(service.Networks.Networks) == 0 {
+		// Add default as network
+		service.Networks = &libCompose_yaml.Networks{
+			Networks: []*libCompose_yaml.Network{
+				{
+					Name:     "default",
+					RealName: project.composeContext.Context.ProjectName+"_default",
+				},
+			},
+		}
+	}
 }
 
 // rewrite mapped service volumes to use app points.


### PR DESCRIPTION
This is an immediate fix for https://github.com/james-nesbitt/kraut-handlers/issues/13

This patch adds a new service alter hook, which duplicates the libcompose.Project network initialization for a service configuration, adding the default network if no networks have been defined.  This path @DUPLICATES some of the libcompose code for default networks.

This fix should cause no issues, but perhaps an upstream fix is more appropriate.  With some small refactoring to the libcompose command code, this fix could be made irrelevant by upstream fixes.
